### PR TITLE
Add type hints (mypy assumed as reference/standard)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,6 +29,20 @@ env:
 
 # ---- Task definitions ----
 
+typecheck_task:
+  name: typecheck (Linux - 3.9)
+  container: {image: "python:3.9-buster"}  # most recent => better type support
+  pip_cache: *pip-cache
+  mypy_cache:
+    folder: .mypy_cache
+  install_script: &debian-install
+    - apt-get install -y git
+  mypy_install_script:
+    - python -m pip install --upgrade pip setuptools mypy -e .
+  typecheck_script:
+    - python -m mypy src
+
+
 linux_mac_task:
   # Use custom cloning since otherwise git tags are missing
   clone_script: &clone |
@@ -43,8 +57,7 @@ linux_mac_task:
   matrix:
     - name: test (Linux - 3.6)
       container: {image: "python:3.6-buster"}
-      install_script: &debian-install
-        - apt-get install -y git
+      install_script: *debian-install
     - name: test (Linux - 3.7)
       container: {image: "python:3.7-buster"}
       install_script: *debian-install

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,8 @@ pretty = True
 show_error_codes = True
 show_error_context = True
 show_traceback = True
+warn_redundant_casts = True
+warn_unused_ignores = True
 
 [pyscaffold]
 # PyScaffold's parameters when the project was created.

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,6 +128,13 @@ exclude =
     .eggs
     docs/conf.py
 
+[mypy]
+ignore_missing_imports = True
+pretty = True
+show_error_codes = True
+show_error_context = True
+show_traceback = True
+
 [pyscaffold]
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,11 +129,11 @@ exclude =
     docs/conf.py
 
 [mypy]
-ignore_missing_imports = True
 pretty = True
 show_error_codes = True
 show_error_context = True
 show_traceback = True
+ignore_missing_imports = True
 warn_redundant_casts = True
 warn_unused_ignores = True
 

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -196,9 +196,9 @@ class Block(ABC, Generic[T]):
         return self._container
 
     @property
-    def container_idx(self) -> int:
+    def container_idx(self: B) -> int:
         """Index of the block within its container"""
-        return self._container.structure.index(self)  # type: ignore
+        return self._container.structure.index(self)
 
     @property
     def updated(self) -> bool:
@@ -358,7 +358,7 @@ class Section(  # type: ignore[misc]
 
     # The following is a pragmatic violation of Liskov substitution principle
     # MutableMapping[str, Option] requires value: Option
-    def __setitem__(self, key: str, value: Optional[str]):  # type: ignore
+    def __setitem__(self, key: str, value: Optional[str]):  # type: ignore[override]
         if self._container.optionxform(key) in self:
             option = self.__getitem__(key)
             option.value = value
@@ -464,7 +464,7 @@ class Section(  # type: ignore[misc]
     # The following is a pragmatic violation of Liskov substitution principle
     # For some reason MutableMapping.items return a Set-like object
     # but we want to preserve ordering
-    def items(self) -> List[Tuple[str, "Option"]]:  # type: ignore
+    def items(self) -> List[Tuple[str, "Option"]]:  # type: ignore[override]
         """Return a list of (name, option) tuples for each option in
         this section.
 
@@ -850,9 +850,11 @@ class ConfigUpdater(  # type: ignore[misc]
         self, block_type: Type[Union[Comment[T], Space[T]]]
     ) -> Union[Comment[T], Space[T]]:
         if isinstance(self.last_block, block_type):
-            return self.last_block  # type: ignore
+            return self.last_block  # type: ignore[return-value]
+            # ^  the type checker is not understanding the isinstance check
         else:
-            new_block = block_type(container=self)  # type: ignore
+            new_block = block_type(container=self)  # type: ignore[arg-type]
+            # ^  the type checker is forgetting ConfigUpdater <: Container[T]
             self._structure.append(new_block)
             return new_block
 
@@ -1034,7 +1036,8 @@ class ConfigUpdater(  # type: ignore[misc]
     ) -> Union[ParsingError, E]:
         e = exc or ParsingError(fpname)
         if hasattr(e, "append"):
-            e.append(lineno, repr(line))  # type: ignore
+            e.append(lineno, repr(line))  # type: ignore[union-attr]
+            # ^  the typechecker cannot handle hasattr
         return e
 
     def _check_values_with_blank_lines(self):
@@ -1204,7 +1207,7 @@ class ConfigUpdater(  # type: ignore[misc]
     # As dicts, Mappings should have get(self, key: str, default: T) -> T
     # but ConfigParser overwrites it and uses the function to offer a different
     # functionality
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def get(self, section: str, option: str) -> Option:
         ...
 
@@ -1272,7 +1275,7 @@ class ConfigUpdater(  # type: ignore[misc]
     # The following is a pragmatic violation of Liskov substitution principle
     # For some reason MutableMapping.items return a Set-like object
     # but we want to preserve ordering
-    @overload  # type: ignore
+    @overload  # type: ignore[override]
     def items(self) -> List[Tuple[str, Section]]:
         ...
 

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -308,15 +308,14 @@ class Section(Block[ConfigBlock], Container[SectionBlock]):
         return self
 
     def _get_option_idx(self, key: str) -> int:
-        idx = [
-            i
-            for i, entry in enumerate(self._structure)
-            if isinstance(entry, Option) and entry.key == key
-        ]
-        if idx:
-            return idx[0]
-        else:
-            raise ValueError
+        try:
+            return next(
+                i
+                for i, entry in enumerate(self._structure)
+                if isinstance(entry, Option) and entry.key == key
+            )
+        except StopIteration:
+            raise ValueError("No option `{}` found".format(key))
 
     def __str__(self) -> str:
         if not self.updated:
@@ -723,15 +722,14 @@ class ConfigUpdater(Container[ConfigBlock]):
         super().__init__()
 
     def _get_section_idx(self, name: str) -> int:
-        idx = [
-            i
-            for i, entry in enumerate(self._structure)
-            if isinstance(entry, Section) and entry.name == name
-        ]
-        if idx:
-            return idx[0]
-        else:
-            raise ValueError
+        try:
+            return next(
+                i
+                for i, entry in enumerate(self._structure)
+                if isinstance(entry, Section) and entry.name == name
+            )
+        except StopIteration:
+            raise ValueError("No section `{}` found".format(name))
 
     def read(self, filename: str, encoding: Optional[str] = None):
         """Read and parse a filename.

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -42,7 +42,6 @@ from configparser import (
     ParsingError,
 )
 from typing import (
-    Any,
     Generic,
     Optional,
     TextIO,
@@ -89,7 +88,7 @@ class NoConfigFileReadError(Error):
 # Used in parser getters to indicate the default behaviour when a specific
 # option is not found it to raise an exception. Created to enable 'None' as
 # a valid fallback value.
-_UNSET: Any = object()
+_UNSET = object()
 
 T = TypeVar("T")
 E = TypeVar("E", bound=Exception)

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -398,7 +398,7 @@ class Section(Block[ConfigContent], Container[SectionContent]):
         Returns:
             dict: dictionary with same content
         """
-        return {opt.key: opt.value for opt in self.option_blocks()}
+        return {opt.key: opt.value for opt in self.iter_options()}
 
     @property
     def name(self) -> str:
@@ -1287,4 +1287,4 @@ class ConfigUpdater(Container[ConfigContent]):
         Returns:
             dict: dictionary with same content
         """
-        return {sect.name: sect.to_dict() for sect in self.section_blocks()}
+        return {sect.name: sect.to_dict() for sect in self.iter_sections()}

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -451,6 +451,24 @@ class Section(
         """
         return next((o for o in self.iter_options() if o.key == key), default)
 
+    @overload
+    def get_option(self, key: str) -> Optional[str]:
+        ...
+
+    @overload
+    def get_option(self, key: str, default: T) -> Union[str, T]:
+        ...
+
+    def get_option(self, key, default=None):
+        """Similar to :meth:`get` and :meth:`dict.get`, but instead of returning an
+        :obj:`Option` object, returns the stored value as a string.
+        """
+        option = self.get(key, _UNSET)
+        if option is _UNSET:
+            return default
+
+        return option.value
+
     # The following is a pragmatic violation of Liskov substitution principle
     # For some reason MutableMapping.items return a Set-like object
     # but we want to preserve ordering

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -30,8 +30,7 @@ import os
 import re
 import sys
 from abc import ABC
-from collections import OrderedDict as _default_dict
-from collections.abc import MutableMapping
+from collections import OrderedDict
 from configparser import (
     ConfigParser,
     DuplicateOptionError,
@@ -42,6 +41,26 @@ from configparser import (
     NoSectionError,
     ParsingError,
 )
+from typing import (
+    Any,
+    Generic,
+    Optional,
+    TextIO,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    no_type_check,
+)
+
+if sys.version_info[:2] >= (3, 9):
+    from collections.abc import Iterable, Iterator
+
+    List = list
+    Dict = dict
+else:
+    from typing import Dict, Iterable, Iterator, List
 
 __all__ = [
     "NoSectionError",
@@ -69,35 +88,45 @@ class NoConfigFileReadError(Error):
 # Used in parser getters to indicate the default behaviour when a specific
 # option is not found it to raise an exception. Created to enable 'None' as
 # a valid fallback value.
-_UNSET = object()
+_UNSET: Any = object()
+
+T = TypeVar("T")
+E = TypeVar("E", bound=Exception)
+C = TypeVar("C", bound="Container")
+B = TypeVar("B", bound="Block")
+S = TypeVar("S", bound="Section")
+U = TypeVar("U", bound="ConfigUpdater")
+BB = TypeVar("BB", bound="BlockBuilder")
+
+ConfigBlock = Union["Section", "Comment", "Space"]
+SectionBlock = Union["Option", "Comment", "Space"]
 
 
-class Container(ABC):
-    """Abstract Mixin Class describing a container that holds blocks"""
+class Container(ABC, Generic[T]):
+    """Abstract Mixin Class describing a container that holds blocks of type ``T``"""
 
-    def __init__(self, **kwargs):
-        self._structure = list()
-        super().__init__(**kwargs)
+    def __init__(self):
+        self._structure: List[T] = []
 
     @property
-    def structure(self):
+    def structure(self) -> List[T]:
         return self._structure
 
     @property
-    def first_block(self):
+    def first_block(self) -> Optional[T]:
         if self._structure:
             return self._structure[0]
         else:
             return None
 
     @property
-    def last_block(self):
+    def last_block(self) -> Optional[T]:
         if self._structure:
             return self._structure[-1]
         else:
             return None
 
-    def _remove_block(self, idx):
+    def _remove_block(self: C, idx: int) -> C:
         """Remove block at index idx within container
 
         Use `.container_idx` of a block to get the index.
@@ -106,34 +135,36 @@ class Container(ABC):
         del self._structure[idx]
         return self
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Number of blocks in container"""
         return len(self._structure)
 
 
-class Block(ABC):
+class Block(ABC, Generic[T]):
     """Abstract Block type holding lines
 
     Block objects hold original lines from the configuration file and hold
     a reference to a container wherein the object resides.
+
+    The type variable ``T`` is a reference for the type of the sibling blocks
+    inside the container.
     """
 
-    def __init__(self, container, **kwargs):
+    def __init__(self, container: Container[T]):
         self._container = container
-        self._lines = []
+        self._lines: List[str] = []
         self._updated = False
-        super().__init__(**kwargs)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "".join(self._lines)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, self.__class__):
             return str(self) == str(other)
         else:
             return False
 
-    def add_line(self, line):
+    def add_line(self: B, line: str) -> B:
         """Add a line to the current block
 
         Args:
@@ -143,37 +174,37 @@ class Block(ABC):
         return self
 
     @property
-    def lines(self):
+    def lines(self) -> List[str]:
         return self._lines
 
     @property
-    def container(self) -> Container:
+    def container(self) -> Container[T]:
         """Container holding the block"""
         return self._container
 
     @property
-    def container_idx(self):
+    def container_idx(self) -> int:
         """Index of the block within its container"""
-        return self._container.structure.index(self)
+        return self._container.structure.index(self)  # type: ignore
 
     @property
-    def updated(self):
+    def updated(self) -> bool:
         """True if the option was changed/updated, otherwise False"""
         # if no lines were added, treat it as updated since we added it
         return self._updated or not self._lines
 
     @property
-    def add_before(self):
+    def add_before(self) -> "BlockBuilder":
         """Block builder inserting a new block before the current block"""
         return BlockBuilder(self._container, self.container_idx)
 
     @property
-    def add_after(self):
+    def add_after(self) -> "BlockBuilder":
         """Block builder inserting a new block after the current block"""
         return BlockBuilder(self._container, self.container_idx + 1)
 
     @property
-    def next_block(self):
+    def next_block(self) -> Optional[T]:
         """Next block in the current container"""
         idx = self.container_idx + 1
         if idx < len(self._container):
@@ -182,7 +213,7 @@ class Block(ABC):
             return None
 
     @property
-    def previous_block(self):
+    def previous_block(self) -> Optional[T]:
         """Previous block in the current container"""
         idx = self.container_idx - 1
         if idx >= 0:
@@ -190,33 +221,33 @@ class Block(ABC):
         else:
             return None
 
-    def remove(self):
+    def remove(self: B) -> B:
         """Remove this block from container"""
         self.container._remove_block(self.container_idx)
         return self
 
 
-class Comment(Block):
+class Comment(Block[T]):
     """Comment block"""
 
-    def __init__(self, container):
+    def __init__(self, container: Container[T]):
         super().__init__(container=container)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Comment>"
 
 
-class Space(Block):
+class Space(Block[T]):
     """Vertical space block of new lines"""
 
-    def __init__(self, container):
+    def __init__(self, container: Container[T]):
         super().__init__(container=container)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Space>"
 
 
-class Section(Block, Container, MutableMapping):
+class Section(Block[ConfigBlock], Container[SectionBlock]):
     """Section block holding options
 
     Attributes:
@@ -224,13 +255,14 @@ class Section(Block, Container, MutableMapping):
         updated (bool): indicates name change or a new section
     """
 
-    def __init__(self, name, container, **kwargs):
+    def __init__(self, name: str, container: "ConfigUpdater"):
+        self._container: "ConfigUpdater" = container
         self._name = name
-        self._structure = list()
+        self._structure: List[SectionBlock] = []
         self._updated = False
-        super().__init__(container=container, **kwargs)
+        super().__init__(container=container)
 
-    def add_option(self, entry):
+    def add_option(self: S, entry: "Option") -> S:
         """Add an Option object to the section
 
         Used during initial parsing mainly
@@ -241,7 +273,7 @@ class Section(Block, Container, MutableMapping):
         self._structure.append(entry)
         return self
 
-    def add_comment(self, line):
+    def add_comment(self: S, line: str) -> S:
         """Add a Comment object to the section
 
         Used during initial parsing mainly
@@ -249,13 +281,16 @@ class Section(Block, Container, MutableMapping):
         Args:
             line (str): one line in the comment
         """
-        if not isinstance(self.last_block, Comment):
+        if isinstance(self.last_block, Comment):
+            comment: Comment = self.last_block
+        else:
             comment = Comment(container=self)
             self._structure.append(comment)
-        self.last_block.add_line(line)
+
+        comment.add_line(line)
         return self
 
-    def add_space(self, line):
+    def add_space(self: S, line: str) -> S:
         """Add a Space object to the section
 
         Used during initial parsing mainly
@@ -263,13 +298,16 @@ class Section(Block, Container, MutableMapping):
         Args:
             line (str): one line that defines the space, maybe whitespaces
         """
-        if not isinstance(self.last_block, Space):
+        if isinstance(self.last_block, Space):
+            space = self.last_block
+        else:
             space = Space(container=self)
             self._structure.append(space)
-        self.last_block.add_line(line)
+
+        space.add_line(line)
         return self
 
-    def _get_option_idx(self, key):
+    def _get_option_idx(self, key: str) -> int:
         idx = [
             i
             for i, entry in enumerate(self._structure)
@@ -280,7 +318,7 @@ class Section(Block, Container, MutableMapping):
         else:
             raise ValueError
 
-    def __str__(self):
+    def __str__(self) -> str:
         if not self.updated:
             s = super().__str__()
         else:
@@ -289,16 +327,19 @@ class Section(Block, Container, MutableMapping):
             s += str(entry)
         return s
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Section: {}>".format(self.name)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> "Option":
         key = self._container.optionxform(key)
         if key not in self.options():
             raise KeyError(key)
-        return self._structure[self._get_option_idx(key=key)]
+        option = self._structure[self._get_option_idx(key=key)]
+        return cast(Option, option)
+        # ^  Since option is listed in self.options() we are sure it is an
+        #    Option object
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Optional[str]):
         if self._container.optionxform(key) in self:
             option = self.__getitem__(key)
             option.value = value
@@ -307,26 +348,26 @@ class Section(Block, Container, MutableMapping):
             option.value = value
             self._structure.append(option)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str):
         if key not in self.options():
             raise KeyError(key)
         idx = self._get_option_idx(key=key)
         del self._structure[idx]
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         return key in self.options()
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SectionBlock]:
         """Return all entries, not just options"""
-        return self._structure.__iter__()
+        return iter(self._structure)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> Any:
         if isinstance(other, self.__class__):
             return self.name == other.name and self._structure == other._structure
         else:
             return False
 
-    def option_blocks(self):
+    def option_blocks(self) -> List["Option"]:
         """Returns option blocks
 
         Returns:
@@ -334,7 +375,7 @@ class Section(Block, Container, MutableMapping):
         """
         return [entry for entry in self._structure if isinstance(entry, Option)]
 
-    def options(self):
+    def options(self) -> List[str]:
         """Returns option names
 
         Returns:
@@ -342,7 +383,7 @@ class Section(Block, Container, MutableMapping):
         """
         return [option.key for option in self.option_blocks()]
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Optional[str]]:
         """Transform to dictionary
 
         Returns:
@@ -351,15 +392,15 @@ class Section(Block, Container, MutableMapping):
         return {key: self.__getitem__(key).value for key in self.options()}
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     @name.setter
-    def name(self, value):
+    def name(self, value: str):
         self._name = str(value)
         self._updated = True
 
-    def set(self, option, value=None):
+    def set(self: S, option: str, value: Optional[str] = None) -> S:
         """Set an option for chaining.
 
         Args:
@@ -373,7 +414,7 @@ class Section(Block, Container, MutableMapping):
             self.__setitem__(option, value)
         return self
 
-    def items(self):
+    def items(self) -> List[Tuple[str, "Option"]]:
         """Return a list of (name, option) tuples for each option in
         this section.
 
@@ -382,7 +423,7 @@ class Section(Block, Container, MutableMapping):
         """
         return [(opt.key, opt) for opt in self.option_blocks()]
 
-    def insert_at(self, idx):
+    def insert_at(self, idx: int) -> "BlockBuilder":
         """Returns a builder inserting a new block at the given index
 
         Args:
@@ -391,7 +432,7 @@ class Section(Block, Container, MutableMapping):
         return BlockBuilder(self, idx)
 
 
-class Option(Block):
+class Option(Block[SectionBlock]):
     """Option block holding a key/value pair.
 
     Attributes:
@@ -402,26 +443,27 @@ class Option(Block):
 
     def __init__(
         self,
-        key,
-        value,
-        container,
-        delimiter="=",
-        space_around_delimiters=True,
-        line=None,
+        key: str,
+        value: Optional[str],
+        container: Section,
+        delimiter: str = "=",
+        space_around_delimiters: bool = True,
+        line: Optional[str] = None,
     ):
+        self._container: Section = container
         super().__init__(container=container)
         self._key = key
-        self._values = [value]
+        self._values: List[Optional[str]] = [value]
         self._value_is_none = value is None
         self._delimiter = delimiter
-        self._value = None  # will be filled after join_multiline_value
+        self._value: Optional[str] = None  # will be filled after join_multiline_value
         self._updated = False
         self._multiline_value_joined = False
         self._space_around_delimiters = space_around_delimiters
         if line:
             super().add_line(line)
 
-    def add_line(self, line):
+    def add_line(self, line: str):
         super().add_line(line)
         self._values.append(line.strip())
 
@@ -431,7 +473,7 @@ class Option(Block):
             self._value = "\n".join(self._values).rstrip()
             self._multiline_value_joined = True
 
-    def __str__(self):
+    def __str__(self) -> str:
         if not self.updated:
             return super().__str__()
         if self._value is None:
@@ -444,32 +486,32 @@ class Option(Block):
             delim = self._delimiter
         return "{}{}{}{}".format(self._key, delim, self._value, "\n")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Option: {} = {}>".format(self.key, self.value)
 
     @property
-    def key(self):
+    def key(self) -> str:
         return self._container._container.optionxform(self._key)
 
     @key.setter
-    def key(self, value):
+    def key(self, value: str):
         self._join_multiline_value()
         self._key = value
         self._updated = True
 
     @property
-    def value(self):
+    def value(self) -> Optional[str]:
         self._join_multiline_value()
         return self._value
 
     @value.setter
-    def value(self, value):
+    def value(self, value: str):
         self._updated = True
         self._multiline_value_joined = True
         self._value = value
         self._values = [value]
 
-    def set_values(self, values, separator="\n", indent=4 * " "):
+    def set_values(self, values: List[str], separator="\n", indent=4 * " "):
         """Sets the value to a given list of options, e.g. multi-line values
 
         Args:
@@ -480,21 +522,21 @@ class Option(Block):
         values = list(values).copy()
         self._updated = True
         self._multiline_value_joined = True
-        self._values = values
+        self._values = cast(List[Optional[str]], values)
         if separator == "\n":
             values = [""] + values
             separator = separator + indent
         self._value = separator.join(values)
 
 
-class BlockBuilder(object):
+class BlockBuilder:
     """Builder that injects blocks at a given index position."""
 
-    def __init__(self, container, idx):
+    def __init__(self, container: Container, idx: int):
         self._container = container
         self._idx = idx
 
-    def comment(self, text, comment_prefix="#"):
+    def comment(self: BB, text: str, comment_prefix="#") -> BB:
         """Creates a comment block
 
         Args:
@@ -514,7 +556,7 @@ class BlockBuilder(object):
         self._idx += 1
         return self
 
-    def section(self, section):
+    def section(self: BB, section) -> BB:
         """Creates a section block
 
         Args:
@@ -538,7 +580,7 @@ class BlockBuilder(object):
         self._idx += 1
         return self
 
-    def space(self, newlines=1):
+    def space(self: BB, newlines=1) -> BB:
         """Creates a vertical space of newlines
 
         Args:
@@ -554,7 +596,7 @@ class BlockBuilder(object):
         self._idx += 1
         return self
 
-    def option(self, key, value=None, **kwargs):
+    def option(self: BB, key, value=None, **kwargs) -> BB:
         """Creates a new option inside a section
 
         Args:
@@ -576,7 +618,7 @@ class BlockBuilder(object):
         return self
 
 
-class ConfigUpdater(Container, MutableMapping):
+class ConfigUpdater(Container[ConfigBlock]):
     """Parser for updating configuration files.
 
     ConfigUpdater follows the API of ConfigParser with some differences:
@@ -595,12 +637,12 @@ class ConfigUpdater(Container, MutableMapping):
     """
 
     # Regular expressions for parsing section headers and options
-    _SECT_TMPL = r"""
+    _SECT_TMPL: str = r"""
         \[                                 # [
         (?P<header>[^]]+)                  # very permissive!
         \]                                 # ]
         """
-    _OPT_TMPL = r"""
+    _OPT_TMPL: str = r"""
         (?P<option>.*?)                    # very permissive!
         \s*(?P<vi>{delim})\s*              # any number of space/tab,
                                            # followed by any of the
@@ -608,7 +650,7 @@ class ConfigUpdater(Container, MutableMapping):
                                            # followed by any space/tab
         (?P<value>.*)$                     # everything up to eol
         """
-    _OPT_NV_TMPL = r"""
+    _OPT_NV_TMPL: str = r"""
         (?P<option>.*?)                    # very permissive!
         \s*(?:                             # any number of space/tab,
         (?P<vi>{delim})\s*                 # optionally followed by
@@ -631,12 +673,12 @@ class ConfigUpdater(Container, MutableMapping):
         self,
         allow_no_value=False,
         *,
-        delimiters=("=", ":"),
-        comment_prefixes=("#", ";"),
-        inline_comment_prefixes=None,
-        strict=True,
-        empty_lines_in_values=True,
-        space_around_delimiters=True
+        delimiters: Tuple[str, ...] = ("=", ":"),
+        comment_prefixes: Tuple[str, ...] = ("#", ";"),
+        inline_comment_prefixes: Optional[Tuple[str, ...]] = None,
+        strict: bool = True,
+        empty_lines_in_values: bool = True,
+        space_around_delimiters: bool = True
     ):
         """Constructor of ConfigUpdater
 
@@ -654,15 +696,15 @@ class ConfigUpdater(Container, MutableMapping):
             space_around_delimiters (bool): add a space before and after the
                 delimiter, default True
         """
-        self._filename = None
-        self._space_around_delimiters = space_around_delimiters
+        self._filename: Optional[str] = None
+        self._space_around_delimiters: bool = space_around_delimiters
 
-        self._dict = _default_dict  # no reason to let the user change this
+        self._dict = OrderedDict  # no reason to let the user change this
         # keeping _sections to keep code aligned with ConfigParser but
         # _structure takes the actual role instead. Only use self._structure!
-        self._sections = self._dict()
-        self._structure = []
-        self._delimiters = tuple(delimiters)
+        self._sections: OrderedDict[str, List[str]] = self._dict()
+        self._structure: List[Union[Comment, Space, Section]] = []
+        self._delimiters: Tuple[str, ...] = tuple(delimiters)
         if delimiters == ("=", ":"):
             self._optcre = self.OPTCRE_NV if allow_no_value else self.OPTCRE
         else:
@@ -671,14 +713,16 @@ class ConfigUpdater(Container, MutableMapping):
                 self._optcre = re.compile(self._OPT_NV_TMPL.format(delim=d), re.VERBOSE)
             else:
                 self._optcre = re.compile(self._OPT_TMPL.format(delim=d), re.VERBOSE)
-        self._comment_prefixes = tuple(comment_prefixes or ())
-        self._inline_comment_prefixes = tuple(inline_comment_prefixes or ())
+        self._comment_prefixes: Tuple[str, ...] = tuple(comment_prefixes or ())
+        self._inline_comment_prefixes: Tuple[str, ...] = tuple(
+            inline_comment_prefixes or ()
+        )
         self._strict = strict
         self._allow_no_value = allow_no_value
         self._empty_lines_in_values = empty_lines_in_values
         super().__init__()
 
-    def _get_section_idx(self, name):
+    def _get_section_idx(self, name: str) -> int:
         idx = [
             i
             for i, entry in enumerate(self._structure)
@@ -689,7 +733,7 @@ class ConfigUpdater(Container, MutableMapping):
         else:
             raise ValueError
 
-    def read(self, filename, encoding=None):
+    def read(self, filename: str, encoding: Optional[str] = None):
         """Read and parse a filename.
 
         Args:
@@ -700,7 +744,7 @@ class ConfigUpdater(Container, MutableMapping):
             self._read(fp, filename)
         self._filename = os.path.abspath(filename)
 
-    def read_file(self, f, source=None):
+    def read_file(self, f: Iterable[str], source: Optional[str] = None):
         """Like read() but the argument must be a file-like object.
 
         The ``f`` argument must be iterable, returning one line at a time.
@@ -716,12 +760,12 @@ class ConfigUpdater(Container, MutableMapping):
             raise RuntimeError("f must be a file-like object, not string!")
         if source is None:
             try:
-                source = f.name
+                source = cast(str, cast(io.FileIO, f).name)
             except AttributeError:
                 source = "<???>"
         self._read(f, source)
 
-    def read_string(self, string, source="<string>"):
+    def read_string(self, string: str, source="<string>"):
         """Read configuration from a given string.
 
         Args:
@@ -731,7 +775,7 @@ class ConfigUpdater(Container, MutableMapping):
         sfile = io.StringIO(string)
         self.read_file(sfile, source)
 
-    def optionxform(self, optionstr):
+    def optionxform(self, optionstr) -> str:
         """Converts an option key to lower case for unification
 
         Args:
@@ -742,17 +786,21 @@ class ConfigUpdater(Container, MutableMapping):
         """
         return optionstr.lower()
 
-    def _update_curr_block(self, block_type):
-        if not isinstance(self.last_block, block_type):
-            new_block = block_type(container=self)
+    def _update_curr_block(
+        self, block_type: Type[Union[Comment[T], Space[T]]]
+    ) -> Union[Comment[T], Space[T]]:
+        if isinstance(self.last_block, block_type):
+            return self.last_block  # type: ignore
+        else:
+            new_block = block_type(container=self)  # type: ignore
             self._structure.append(new_block)
+            return new_block
 
     def _add_comment(self, line):
         if isinstance(self.last_block, Section):
             self.last_block.add_comment(line)
         else:
-            self._update_curr_block(Comment)
-            self.last_block.add_line(line)
+            self._update_curr_block(Comment).add_line(line)
 
     def _add_section(self, sectname, line):
         new_section = Section(sectname, container=self)
@@ -768,16 +816,19 @@ class ConfigUpdater(Container, MutableMapping):
             space_around_delimiters=self._space_around_delimiters,
             line=line,
         )
+        assert isinstance(self.last_block, Section)
+        # TODO: Replace the assertion with proper handling
+        #       Why last_block was not being checked before?
         self.last_block.add_option(entry)
 
     def _add_space(self, line):
         if isinstance(self.last_block, Section):
-            self.last_block.add_space(line)
+            self.last_block.add_space(line)  # type: ignore
         else:
-            self._update_curr_block(Space)
-            self.last_block.add_line(line)
+            self._update_curr_block(Space).add_line(line)
 
-    def _read(self, fp, fpname):
+    @no_type_check
+    def _read(self, fp: Iterable[str], fpname: str):
         """Parse a sectioned configuration file.
 
         Each section in a configuration file contains a header, indicated by
@@ -918,11 +969,13 @@ class ConfigUpdater(Container, MutableMapping):
         if self._empty_lines_in_values:
             self._check_values_with_blank_lines()
 
-    def _handle_error(self, exc, fpname, lineno, line):
-        if not exc:
-            exc = ParsingError(fpname)
-        exc.append(lineno, repr(line))
-        return exc
+    def _handle_error(
+        self, exc: Optional[E], fpname: str, lineno: int, line: str
+    ) -> Union[ParsingError, E]:
+        e = exc or ParsingError(fpname)
+        if hasattr(e, "append"):
+            e.append(lineno, repr(line))  # type: ignore
+        return e
 
     def _check_values_with_blank_lines(self):
         for section in self.section_blocks():
@@ -933,7 +986,7 @@ class ConfigUpdater(Container, MutableMapping):
                     if "".join(next_block.lines).strip():
                         self._merge_option_with_space(option, next_block)
 
-    def _merge_option_with_space(self, option, space):
+    def _merge_option_with_space(self, option: Option, space: Space):
         last_val_idx = max(i for i, line in enumerate(space.lines) if line.strip())
         value_lines = space.lines[: last_val_idx + 1]
         merge_vals = "".join(line.lstrip(" ") for line in value_lines)
@@ -942,7 +995,8 @@ class ConfigUpdater(Container, MutableMapping):
         option.lines.extend(space.lines[: last_val_idx + 1])
         del space.lines[: last_val_idx + 1]
 
-    def write(self, fp, validate=True):
+    def write(self, fp: TextIO, validate: bool = True):
+        # TODO: For Python>=3.8 instead of TextIO we can define a Writeable protocol
         """Write an .ini-format representation of the configuration state.
 
         Args:
@@ -953,7 +1007,7 @@ class ConfigUpdater(Container, MutableMapping):
             self.validate_format()
         fp.write(str(self))
 
-    def update_file(self, validate=True):
+    def update_file(self, validate: bool = True):
         """Update the read-in configuration file.
 
         Args:
@@ -984,7 +1038,7 @@ class ConfigUpdater(Container, MutableMapping):
         updated_cfg = str(self)
         parser.read_string(updated_cfg)
 
-    def section_blocks(self):
+    def section_blocks(self) -> List[Section]:
         """Returns all section blocks
 
         Returns:
@@ -992,7 +1046,7 @@ class ConfigUpdater(Container, MutableMapping):
         """
         return [block for block in self._structure if isinstance(block, Section)]
 
-    def sections(self):
+    def sections(self) -> List[str]:
         """Return a list of section names
 
         Returns:
@@ -1000,17 +1054,17 @@ class ConfigUpdater(Container, MutableMapping):
         """
         return [section.name for section in self.section_blocks()]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "".join(str(block) for block in self._structure)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> Section:
         for section in self.section_blocks():
             if section.name == key:
                 return section
-        else:
-            raise KeyError(key)
 
-    def __setitem__(self, key, value):
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Section):
         if not isinstance(value, Section):
             raise ValueError("Value must be of type Section!")
         if isinstance(key, str) and key in self:
@@ -1022,25 +1076,25 @@ class ConfigUpdater(Container, MutableMapping):
             value.name = key
             self.add_section(value)
 
-    def __delitem__(self, section):
+    def __delitem__(self, section: str):
         if not self.has_section(section):
             raise KeyError(section)
         self.remove_section(section)
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         return self.has_section(key)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[ConfigBlock]:
         """Iterate over all blocks, not just sections"""
-        return self._structure.__iter__()
+        return iter(self._structure)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, self.__class__):
             return self._structure == other._structure
         else:
             return False
 
-    def add_section(self, section):
+    def add_section(self, section: Union[str, Section]):
         """Create a new section in the configuration.
 
         Raise DuplicateSectionError if a section by the specified name
@@ -1049,16 +1103,20 @@ class ConfigUpdater(Container, MutableMapping):
         Args:
             section (str or :class:`Section`): name or Section type
         """
-        if section in self.sections():
-            raise DuplicateSectionError(section)
         if isinstance(section, str):
             # create a new section
-            section = Section(section, container=self)
-        elif not isinstance(section, Section):
+            section_obj = Section(section, container=self)
+        elif isinstance(section, Section):
+            section_obj = section
+        else:
             raise ValueError("Parameter must be a string or Section type!")
-        self._structure.append(section)
 
-    def has_section(self, section):
+        if section_obj.name in self.sections():
+            raise DuplicateSectionError(section_obj.name)
+
+        self._structure.append(section_obj)
+
+    def has_section(self, section: str) -> bool:
         """Returns whether the given section exists.
 
         Args:
@@ -1069,7 +1127,7 @@ class ConfigUpdater(Container, MutableMapping):
         """
         return section in self.sections()
 
-    def options(self, section):
+    def options(self, section: str) -> List[str]:
         """Returns list of configuration options for the named section.
 
         Args:
@@ -1082,7 +1140,7 @@ class ConfigUpdater(Container, MutableMapping):
             raise NoSectionError(section) from None
         return self.__getitem__(section).options()
 
-    def get(self, section, option, fallback=_UNSET):
+    def get(self, section: str, option: str, fallback=_UNSET) -> Option:
         """Gets an option value for a given section.
 
         Args:
@@ -1097,16 +1155,16 @@ class ConfigUpdater(Container, MutableMapping):
         if not self.has_section(section):
             raise NoSectionError(section) from None
 
-        section = self.__getitem__(section)
+        section_obj = self.__getitem__(section)
         option = self.optionxform(option)
         try:
-            return section[option]
+            return section_obj[option]
         except KeyError:
             if fallback is _UNSET:
                 raise NoOptionError(option, section)
             return fallback
 
-    def items(self, section=_UNSET):
+    def items(self, section=_UNSET) -> List[Tuple[Any, Any]]:
         """Return a list of (name, value) tuples for options or sections.
 
         If section is given, return a list of tuples with (name, value) for
@@ -1125,7 +1183,7 @@ class ConfigUpdater(Container, MutableMapping):
         section = self.__getitem__(section)
         return [(opt.key, opt) for opt in section.option_blocks()]
 
-    def has_option(self, section, option):
+    def has_option(self, section: str, option: str) -> bool:
         """Checks for the existence of a given option in a given section.
 
         Args:
@@ -1141,7 +1199,7 @@ class ConfigUpdater(Container, MutableMapping):
             option = self.optionxform(option)
             return option in self[section]
 
-    def set(self, section, option, value=None):
+    def set(self: U, section: str, option: str, value: Optional[str] = None) -> U:
         """Set an option.
 
         Args:
@@ -1150,17 +1208,17 @@ class ConfigUpdater(Container, MutableMapping):
             value (str): value, default None
         """
         try:
-            section = self.__getitem__(section)
+            section_obj = self.__getitem__(section)
         except KeyError:
             raise NoSectionError(section) from None
         option = self.optionxform(option)
-        if option in section:
-            section[option].value = value
+        if option in section_obj:
+            section_obj[option].value = value
         else:
-            section[option] = value
+            section_obj[option] = value
         return self
 
-    def remove_option(self, section, option):
+    def remove_option(self, section: str, option: str) -> bool:
         """Remove an option.
 
         Args:
@@ -1171,16 +1229,16 @@ class ConfigUpdater(Container, MutableMapping):
             bool: whether the option was actually removed
         """
         try:
-            section = self.__getitem__(section)
+            section_obj = self.__getitem__(section)
         except KeyError:
             raise NoSectionError(section) from None
         option = self.optionxform(option)
-        existed = option in section.options()
+        existed = option in section_obj.options()
         if existed:
-            del section[option]
+            del section_obj[option]
         return existed
 
-    def remove_section(self, name):
+    def remove_section(self, name: str) -> bool:
         """Remove a file section.
 
         Args:
@@ -1195,7 +1253,7 @@ class ConfigUpdater(Container, MutableMapping):
             del self._structure[idx]
         return existed
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Dict[str, Optional[str]]]:
         """Transform to dictionary
 
         Returns:

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -1244,7 +1244,7 @@ class ConfigUpdater(Container[ConfigContent], MutableMapping[str, Section]):
             raise NoSectionError(section) from None
 
         option = self.optionxform(option)
-        value = cast(Section, section_obj).get(option, fallback)
+        value = section_obj.get(option, fallback)
         # ^  we checked section_obj against _UNSET, so we are sure about its type
 
         if value is _UNSET:

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -1153,11 +1153,7 @@ class ConfigUpdater(Container[ConfigContent]):
         ...
 
     @overload
-    def get(self, section: str, option: str, fallback: None) -> None:  # noqa
-        ...
-
-    @overload
-    def get(self, section: str, option: str, fallback: Option) -> Option:  # noqa
+    def get(self, section: str, option: str, fallback: T) -> Union[Option, T]:  # noqa
         ...
 
     def get(self, section, option, fallback=_UNSET):  # noqa

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -98,8 +98,8 @@ S = TypeVar("S", bound="Section")
 U = TypeVar("U", bound="ConfigUpdater")
 BB = TypeVar("BB", bound="BlockBuilder")
 
-ConfigBlock = Union["Section", "Comment", "Space"]
-SectionBlock = Union["Option", "Comment", "Space"]
+ConfigContent = Union["Section", "Comment", "Space"]
+SectionContent = Union["Option", "Comment", "Space"]
 
 
 class Container(ABC, Generic[T]):
@@ -247,7 +247,7 @@ class Space(Block[T]):
         return "<Space>"
 
 
-class Section(Block[ConfigBlock], Container[SectionBlock]):
+class Section(Block[ConfigContent], Container[SectionContent]):
     """Section block holding options
 
     Attributes:
@@ -258,7 +258,7 @@ class Section(Block[ConfigBlock], Container[SectionBlock]):
     def __init__(self, name: str, container: "ConfigUpdater"):
         self._container: "ConfigUpdater" = container
         self._name = name
-        self._structure: List[SectionBlock] = []
+        self._structure: List[SectionContent] = []
         self._updated = False
         super().__init__(container=container)
 
@@ -360,7 +360,7 @@ class Section(Block[ConfigBlock], Container[SectionBlock]):
         """
         return next((True for o in self.iter_options() if o.key == key), False)
 
-    def __iter__(self) -> Iterator[SectionBlock]:
+    def __iter__(self) -> Iterator[SectionContent]:
         """Return all entries, not just options"""
         return iter(self._structure)
 
@@ -441,7 +441,7 @@ class Section(Block[ConfigBlock], Container[SectionBlock]):
         return BlockBuilder(self, idx)
 
 
-class Option(Block[SectionBlock]):
+class Option(Block[SectionContent]):
     """Option block holding a key/value pair.
 
     Attributes:
@@ -627,7 +627,7 @@ class BlockBuilder:
         return self
 
 
-class ConfigUpdater(Container[ConfigBlock]):
+class ConfigUpdater(Container[ConfigContent]):
     """Parser for updating configuration files.
 
     ConfigUpdater follows the API of ConfigParser with some differences:
@@ -1103,7 +1103,7 @@ class ConfigUpdater(Container[ConfigBlock]):
 
     has_section = __contains__
 
-    def __iter__(self) -> Iterator[ConfigBlock]:
+    def __iter__(self) -> Iterator[ConfigContent]:
         """Iterate over all blocks, not just sections"""
         return iter(self._structure)
 

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -137,8 +137,6 @@ def test_get_section(setup_cfg_path):
     assert section._structure
     with pytest.raises(KeyError):
         updater["non_existent_section"]
-    with pytest.raises(ValueError):
-        updater._get_section_idx("non_existent_section")
 
 
 def test_section_to_dict(setup_cfg_path):
@@ -384,8 +382,6 @@ def test_del_section():
     assert str(updater) == test2_cfg_out
     with pytest.raises(KeyError):
         del updater["section2"]
-    with pytest.raises(ValueError):
-        updater["section1"]._get_option_idx("wrong key")
 
 
 test_wrong_cfg = """

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -141,6 +141,11 @@ def test_get_section(setup_cfg_path):
     with pytest.raises(KeyError):
         updater["non_existent_section"]
 
+    # `get_section` is equivalent to dict.get
+    assert updater.get_section("non_existent_section") is None
+    default = {}
+    assert updater.get_section("non_existent_section", default) is default
+
 
 def test_section_to_dict(setup_cfg_path):
     updater = ConfigUpdater()
@@ -202,6 +207,16 @@ def test_get_options(setup_cfg_path):
     assert options == exp_options
     with pytest.raises(NoSectionError):
         updater.options("non_existent_section")
+
+    # Section objects also have a "get" method similar to dict
+    section = updater["metadata"]
+    assert section.get("name").value == "configupdater"
+    assert section.get("non_existent_option") is None
+    assert section.get("non_existent_option", []) == []
+    # and a `get_option` that unwraps the inner value
+    assert section.get_option("name") == "configupdater"
+    assert section.get_option("non_existent_option") is None
+    assert section.get_option("non_existent_option", []) == []
 
 
 def test_items(setup_cfg_path):

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -108,8 +108,11 @@ def test_len_updater(setup_cfg_path):
 def test_iter_section(setup_cfg_path):
     updater = ConfigUpdater()
     updater.read(setup_cfg_path)
-    # we test the number of blocks, not sections
-    assert len([block for block in updater]) == 14
+    # iter_blocks will give us everything, iter_sections just the section objects and
+    # __iter__ just the keys of the section objects
+    assert len([block for block in updater.iter_blocks()]) == 14
+    assert len([block for block in updater.iter_sections()]) == 12
+    assert len([entry for entry in updater]) == 12
 
 
 def test_iter_items_section(setup_cfg_path):
@@ -184,8 +187,11 @@ def test_iter_option(setup_cfg_path):
     updater = ConfigUpdater()
     updater.read(setup_cfg_path)
     section = updater["metadata"]
-    # we test the number of entries, not options
-    assert len([entry for entry in section]) == 12
+    # iter_blocks will give us everything, iter_options just the option objects and
+    # __iter__ just the keys of the option objects
+    assert len([entry for entry in section.iter_blocks()]) == 12
+    assert len([entry for entry in section.iter_options()]) == 9
+    assert len([entry for entry in section]) == 9
 
 
 def test_get_options(setup_cfg_path):

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -109,10 +109,10 @@ def test_iter_section(setup_cfg_path):
     updater = ConfigUpdater()
     updater.read(setup_cfg_path)
     # iter_blocks will give us everything, iter_sections just the section objects and
-    # __iter__ just the keys of the section objects
+    # __iter__ should work as iter_blocks
     assert len([block for block in updater.iter_blocks()]) == 14
     assert len([block for block in updater.iter_sections()]) == 12
-    assert len([entry for entry in updater]) == 12
+    assert len([entry for entry in updater]) == 14
 
 
 def test_iter_items_section(setup_cfg_path):
@@ -193,10 +193,10 @@ def test_iter_option(setup_cfg_path):
     updater.read(setup_cfg_path)
     section = updater["metadata"]
     # iter_blocks will give us everything, iter_options just the option objects and
-    # __iter__ just the keys of the option objects
+    # __iter__ should work as iter_blocks
     assert len([entry for entry in section.iter_blocks()]) == 12
     assert len([entry for entry in section.iter_options()]) == 9
-    assert len([entry for entry in section]) == 9
+    assert len([entry for entry in section]) == 12
 
 
 def test_get_options(setup_cfg_path):

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -213,10 +213,6 @@ def test_get_options(setup_cfg_path):
     assert section.get("name").value == "configupdater"
     assert section.get("non_existent_option") is None
     assert section.get("non_existent_option", []) == []
-    # and a `get_option` that unwraps the inner value
-    assert section.get_option("name") == "configupdater"
-    assert section.get_option("non_existent_option") is None
-    assert section.get_option("non_existent_option", []) == []
 
 
 def test_items(setup_cfg_path):

--- a/tox.ini
+++ b/tox.ini
@@ -28,18 +28,22 @@ commands =
 description =
     Build (or clean) the package in isolation according to instructions in:
     https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
-# NOTE: pep517.build is transitional, please refer to the link for updates
+    https://github.com/pypa/pep517/issues/91
+    https://github.com/pypa/build
+# NOTE: build is still experimental, please refer to the links for updates/issues
 skip_install = True
 changedir = {toxinidir}
 deps =
-    build: pep517
+    build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
-    build: python -m pep517.build .
+    build: python -m build .
+# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
 
 
 [testenv:{docs,doctests}]
 description = invoke sphinx-build to build the docs/run doctests
+usedevelop = True
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build
@@ -47,6 +51,7 @@ setenv =
     doctests: BUILD = doctest
 deps =
     -r {toxinidir}/docs/requirements.txt
+    # ^  requirements.txt shared with Read The Docs
 commands =
     sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,11 +46,21 @@ setenv =
     docs: BUILD = html
     doctests: BUILD = doctest
 deps =
-    sphinx
-    # sphinx_rtd_theme
-    # any docs/requirements.txt for/shared with Read The Docs?
+    -r {toxinidir}/docs/requirements.txt
 commands =
     sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
+
+
+[testenv:typecheck]
+description = invoke mypy to typecheck the source code
+changedir = {toxinidir}
+passenv =
+    TERM
+    # ^ ensure colors
+deps =
+    mypy
+commands =
+    python -m mypy src
 
 
 [testenv:publish]


### PR DESCRIPTION
This is an attempt to start addressing issue #16.

Adding type checking to an untyped codebase is usually a challenge and
sometimes require pragmatic approaches, such as the one adopted in this
commit.

`# type: ignore` and `cast` are used sporadically, but still present when the
type checker is not "smart enough", when the current Python syntax does
not allow expressing the most correct type information or when it was
too hard to introduce it.

It was necessary to remove explicit inheritance from `MuttableMapping`,
since the abstract methods are being overwritten with a non matching
signature that is more convenient for ConfigUpdater.

Functions that use `_UNSET` need to be annotated using `overload`

---
As a quick report, the process used to produce the type annotations was
"semi-manual", with the following steps:

1. Using `pytype` as type checker, the type errors were debugged and
   fixed or "workaround"-ed
2. Using `pytype`, initial type stubs were created
3. Using `retype`, the type stubs were merged back into the source code
   (for some reason `pytype`'s `merge-pyi` did not work)
4. Manual checking/refactoring/fixing of the annotated file
5. Introduction of new annotations not generated by `pytype`
6. Using `mypy` as type checker, the type errors were debugged and fixed
   or "workaround"-ed

mypy does seem to have a tool for generating type stubs, but I have
never worked with it...