### PR TITLE
Edge case when transferring blocks

### DIFF
--- a/tests/test_transfer_blocks.py
+++ b/tests/test_transfer_blocks.py
@@ -1,0 +1,46 @@
+from copy import copy
+from textwrap import dedent
+
+from configupdater import ConfigUpdater
+
+
+def test_transfering_blocks_between_elements():
+    # Let's say a user have a big new section that it wants to insert in an existing
+    # document. Instead of programmatically creating this new section using the builder
+    # API, they might be tempted to parse this new section from template files.
+
+    existing = """\
+    [section0]
+    option0 = 0
+    """
+
+    template1 = """\
+    [section1]
+    option1 = 1
+    """
+
+    template2 = """\
+    [section2]
+    option2 = 2
+    # comment
+    """
+
+    target = ConfigUpdater()
+    target.read_string(dedent(existing))
+
+    source1 = ConfigUpdater()
+    source1.read_string(dedent(template1))
+
+    source2 = ConfigUpdater()
+    source2.read_string(dedent(template2))
+
+    target["section1"] = copy(source1["section1"])
+    assert "section1" in target
+
+    target["section1"].add_after.section(copy(source2["section2"]))
+    # Help with debugging
+    print(f"@@@ target:\n{target}")
+    print(f"@@@ source1:\n{source1}")
+    print(f"@@@ source2:\n{source2}")
+    assert "section2" not in source1
+    assert "section2" in target


### PR DESCRIPTION
This is actually an issue disguised as a PR (I thought it was easier if I provided the test case that is failing and let the CI show it fails).

The issue is as follows:

- All the blocks in the ConfigUpdater hierarchy have a `container` reference, but when you move the block around that reference not necessarily is removed (the types are safe for the time being because `block._container: Container[T]`, so in no moment the current implementation considers the possibility of `block._container` being `None` or even add checks for it).
- This reference is used in the block builder API
- If a node is removed from its parent, or it is imported into a different parent, then there might be inconsistencies, and the block builder API might do something unexpected.

The example implemented in the test case shows section nodes being parsed from text and added to a different document.
When we import a section from a different ConfigUpdater object, its internal reference to its container does not change.
So if we use the `add_after` method to add a new block, this new block will be added to the wrong container.

This happens even if we use `copy` and even if we get a completely new reference to the `section` object after it is added, using the correct parent.