### PR TITLE
Make sure blocks are dettached before inserting into containers

### DIFF
--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -21,6 +21,13 @@ T = TypeVar("T")
 B = TypeVar("B", bound="Block")
 
 
+class NotAttachedError(Exception):
+    """The block is not attached to a container yet. Try to insert it first."""
+
+    def __init__(self):
+        super().__init__(self.__class__.__doc__)
+
+
 class Block(ABC, Generic[T]):
     """Abstract Block type holding lines
 
@@ -31,7 +38,7 @@ class Block(ABC, Generic[T]):
     inside the container.
     """
 
-    def __init__(self, container: "Container[T]"):
+    def __init__(self, container: Optional["Container[T]"] = None):
         self._container = container
         self._lines: List[str] = []
         self._updated = False
@@ -67,12 +74,14 @@ class Block(ABC, Generic[T]):
     @property
     def container(self) -> "Container[T]":
         """Container holding the block"""
+        if self._container is None:
+            raise NotAttachedError
         return self._container
 
     @property
     def container_idx(self: B) -> int:
         """Index of the block within its container"""
-        return self._container.structure.index(self)
+        return self.container.structure.index(self)
 
     @property
     def updated(self) -> bool:
@@ -83,7 +92,7 @@ class Block(ABC, Generic[T]):
     def _builder(self, idx: int) -> "BlockBuilder":
         from .builder import BlockBuilder
 
-        return BlockBuilder(self._container, idx)
+        return BlockBuilder(self.container, idx)
 
     @property
     def add_before(self) -> "BlockBuilder":
@@ -99,8 +108,8 @@ class Block(ABC, Generic[T]):
     def next_block(self) -> Optional[T]:
         """Next block in the current container"""
         idx = self.container_idx + 1
-        if idx < len(self._container):
-            return self._container.structure[idx]
+        if idx < len(self.container):
+            return self.container.structure[idx]
         else:
             return None
 
@@ -109,13 +118,24 @@ class Block(ABC, Generic[T]):
         """Previous block in the current container"""
         idx = self.container_idx - 1
         if idx >= 0:
-            return self._container.structure[idx]
+            return self.container.structure[idx]
         else:
             return None
 
     def remove(self: B) -> B:
         """Remove this block from container"""
         self.container._remove_block(self.container_idx)
+        return self._detach()
+
+    def is_attached(self) -> bool:
+        return not (self._container is None)
+
+    def _attach(self: B, container: "Container[T]") -> B:
+        self._container = container
+        return self
+
+    def _detach(self: B) -> B:
+        self._container = None
         return self
 
 

--- a/src/configupdater/builder.py
+++ b/src/configupdater/builder.py
@@ -5,6 +5,7 @@ from configparser import DuplicateOptionError, DuplicateSectionError
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
+    from .block import Block
     from .container import Container
 
 T = TypeVar("T", bound="BlockBuilder")
@@ -16,6 +17,11 @@ class BlockBuilder:
     def __init__(self, container: "Container", idx: int):
         self._container = container
         self._idx = idx
+
+    def insert(self: T, block: "Block") -> T:
+        self._container.insert(self._idx, block)
+        self._idx += 1
+        return self
 
     def comment(self: T, text: str, comment_prefix="#") -> T:
         """Creates a comment block
@@ -34,10 +40,7 @@ class BlockBuilder:
             text = "{} {}".format(comment_prefix, text)
         if not text.endswith("\n"):
             text = "{}{}".format(text, "\n")
-        comment.add_line(text)
-        self._container.structure.insert(self._idx, comment)
-        self._idx += 1
-        return self
+        return self.insert(comment.add_line(text))
 
     def section(self: T, section) -> T:
         """Creates a section block
@@ -65,9 +68,7 @@ class BlockBuilder:
         if container.has_section(section.name):
             raise DuplicateSectionError(section.name)
 
-        self._container.structure.insert(self._idx, section)
-        self._idx += 1
-        return self
+        return self.insert(section)
 
     def space(self: T, newlines=1) -> T:
         """Creates a vertical space of newlines
@@ -83,9 +84,7 @@ class BlockBuilder:
         space = Space(container=self._container)
         for _ in range(newlines):
             space.add_line("\n")
-        self._container.structure.insert(self._idx, space)
-        self._idx += 1
-        return self
+        return self.insert(space)
 
     def option(self: T, key, value=None, **kwargs) -> T:
         """Creates a new option inside a section
@@ -108,6 +107,4 @@ class BlockBuilder:
         if option.key in self._container.options():
             raise DuplicateOptionError(self._container.name, option.key)
         option.value = value
-        self._container.structure.insert(self._idx, option)
-        self._idx += 1
-        return self
+        return self.insert(option)

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -18,7 +18,8 @@ if sys.version_info[:2] >= (3, 9):  # pragma: no cover
 else:  # pragma: no cover
     from typing import Iterable
 
-from .block import Comment, Space
+from .block import Comment, NotAttachedError, Space
+from .container import AlreadyAttachedWarning
 from .document import Document
 from .option import Option
 from .parser import Parser
@@ -32,6 +33,8 @@ __all__ = [
     "Space",
     "Parser",
     "NoConfigFileReadError",
+    "NotAttachedError",
+    "AlreadyAttachedWarning",
 ]
 
 T = TypeVar("T", bound="ConfigUpdater")

--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -128,8 +128,8 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
             raise ValueError("Value must be of type Section!")
         if isinstance(key, str) and key in self:
             idx = self._get_section_idx(key)
-            del self._structure[idx]
-            self._structure.insert(idx, value)
+            self._structure.pop(idx)._detach()
+            self.insert(idx, value)
         else:
             # name the section by the key
             value.name = key
@@ -161,7 +161,7 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
             return False
 
     def clear(self):
-        self._structure.clear()
+        self._remove_all()
 
     def add_section(self, section: Union[str, Section]):
         """Create a new section in the configuration.
@@ -183,7 +183,7 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
         if self.has_section(section_obj.name):
             raise DuplicateSectionError(section_obj.name)
 
-        self._structure.append(section_obj)
+        self.append(section_obj)
 
     def options(self, section: str) -> List[str]:
         """Returns list of configuration options for the named section.
@@ -360,7 +360,7 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
         """
         try:
             idx = self._get_section_idx(name)
-            del self._structure[idx]
+            self._structure.pop(idx)._detach()
             return True
         except StopIteration:
             return False

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -65,6 +65,7 @@ class Option(Block[SectionContent]):
         """
         super().add_line(line)
         self._values.append(line.strip())
+        return self
 
     def _join_multiline_value(self):
         if not self._multiline_value_joined and not self._value_is_none:

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -62,8 +62,7 @@ class Section(
         Args:
             entry (Option): key value pair as Option object
         """
-        self._structure.append(entry)
-        return self
+        return self.append(entry)
 
     def add_comment(self: S, line: str) -> S:
         """Add a Comment object to the section
@@ -77,7 +76,7 @@ class Section(
             comment: Comment = self.last_block
         else:
             comment = Comment(container=self)
-            self._structure.append(comment)
+            self.append(comment)
 
         comment.add_line(line)
         return self
@@ -94,7 +93,7 @@ class Section(
             space = self.last_block
         else:
             space = Space(container=self)
-            self._structure.append(space)
+            self.append(space)
 
         space.add_line(line)
         return self
@@ -129,12 +128,11 @@ class Section(
         if self._container.optionxform(key) in self:
             if isinstance(value, Option):
                 if value.key != key:
-                    raise ValueError(
-                        f"Set key {key} does not equal option key {value.key}"
-                    )
+                    msg = f"Set key {key} does not equal option key {value.key}"
+                    raise ValueError(msg)
                 idx = self.__getitem__(key).container_idx
-                del self.structure[idx]
-                self.structure.insert(idx, value)
+                self._structure.pop(idx)._detach()
+                self.insert(idx, value)
             else:
                 option = self.__getitem__(key)
                 option.value = value
@@ -144,12 +142,12 @@ class Section(
             else:
                 option = Option(key, value, container=self)
                 option.value = value
-            self._structure.append(option)
+            self.append(option)
 
     def __delitem__(self, key: str):
         try:
             idx = self._get_option_idx(key=key)
-            del self._structure[idx]
+            self._structure.pop(idx)._detach()
         except StopIteration as ex:
             raise KeyError(f"No option `{key}` found", {"key": key}) from ex
 
@@ -264,4 +262,4 @@ class Section(
         return BlockBuilder(self, idx)
 
     def clear(self):
-        self._structure.clear()
+        self._remove_all()

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -6,6 +6,7 @@ from io import StringIO
 import pytest
 
 from configupdater import (
+    AlreadyAttachedWarning,
     Comment,
     ConfigUpdater,
     DuplicateOptionError,
@@ -553,7 +554,8 @@ def test_add_before_after_section():
     sect_updater.read_string(test6_cfg_in)
     section = sect_updater["section0"]
     section.name = "new_section"
-    updater["section2"].add_after.section(section)
+    with pytest.warns(AlreadyAttachedWarning):
+        updater["section2"].add_after.section(section)
     assert str(updater) == test6_cfg_out_new_sect
     with pytest.raises(DuplicateSectionError):
         updater["section2"].add_after.section(section)
@@ -608,14 +610,14 @@ def test_set_item_section():
         updater["section"] = "newsection"
     sect_updater.read_string(test6_cfg_in)
     section = sect_updater["section0"]
-    updater["new_section"] = section
+    updater["new_section"] = section.remove()
     assert str(updater) == test6_cfg_out_new_sect
     # test overwriting an existing section
     updater.read_string(test6_cfg_in)
     sect_updater.read_string(test6_cfg_in)
     exist_section = sect_updater["section0"]
     exist_section["key0"] = 42
-    updater["section0"] = exist_section
+    updater["section0"] = exist_section.remove()
     assert str(updater) == test6_cfg_out_overwritten
 
 

--- a/tests/test_transfer_blocks.py
+++ b/tests/test_transfer_blocks.py
@@ -1,0 +1,46 @@
+from copy import copy
+from textwrap import dedent
+
+from configupdater import ConfigUpdater
+
+
+def test_transfering_blocks_between_elements():
+    # Let's say a user have a big new section that it wants to insert in an existing
+    # document. Instead of programmatically creating this new section using the builder
+    # API, they might be tempted to parse this new section from template files.
+
+    existing = """\
+    [section0]
+    option0 = 0
+    """
+
+    template1 = """\
+    [section1]
+    option1 = 1
+    """
+
+    template2 = """\
+    [section2]
+    option2 = 2
+    # comment
+    """
+
+    target = ConfigUpdater()
+    target.read_string(dedent(existing))
+
+    source1 = ConfigUpdater()
+    source1.read_string(dedent(template1))
+
+    source2 = ConfigUpdater()
+    source2.read_string(dedent(template2))
+
+    target["section1"] = copy(source1["section1"])
+    assert "section1" in target
+
+    target["section1"].add_after.section(copy(source2["section2"]))
+    # Help with debugging
+    print(f"@@@ target:\n{target}")
+    print(f"@@@ source1:\n{source1}")
+    print(f"@@@ source2:\n{source2}")
+    assert "section2" not in source1
+    assert "section2" in target

--- a/tests/test_transfer_blocks.py
+++ b/tests/test_transfer_blocks.py
@@ -1,4 +1,3 @@
-from copy import copy
 from textwrap import dedent
 
 from configupdater import ConfigUpdater
@@ -34,10 +33,10 @@ def test_transfering_blocks_between_elements():
     source2 = ConfigUpdater()
     source2.read_string(dedent(template2))
 
-    target["section1"] = copy(source1["section1"])
+    target["section1"] = source1["section1"].remove()
     assert "section1" in target
 
-    target["section1"].add_after.section(copy(source2["section2"]))
+    target["section1"].add_after.section(source2["section2"].remove())
     # Help with debugging
     print(f"@@@ target:\n{target}")
     print(f"@@@ source1:\n{source1}")


### PR DESCRIPTION
This is a proposal on how to fix #31.

Sorry if the PR was too big again :/
Unfortunately what I am proposing here involves solving the problem between `Container` and `Block`, but then I also had to modify the classes that rely on the parent class behaviour or access the protected variables directly :/

This PR also breaks the type checker, because some cycles are introduced (the tests should pass though).
I do have a follow up PR fixing the types (#36).