### PR TITLE
Remove parametric polymorphism from block

### DIFF
--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -6,7 +6,7 @@ configuration file, e.g. comments, sections, options and even sequences of white
 """
 import sys
 from abc import ABC
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
     List = list
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from .builder import BlockBuilder
     from .container import Container
 
-T = TypeVar("T")
 B = TypeVar("B", bound="Block")
 
 
@@ -28,17 +27,14 @@ class NotAttachedError(Exception):
         super().__init__(self.__class__.__doc__)
 
 
-class Block(ABC, Generic[T]):
+class Block(ABC):
     """Abstract Block type holding lines
 
     Block objects hold original lines from the configuration file and hold
     a reference to a container wherein the object resides.
-
-    The type variable ``T`` is a reference for the type of the sibling blocks
-    inside the container.
     """
 
-    def __init__(self, container: Optional["Container[T]"] = None):
+    def __init__(self, container: Optional["Container"] = None):
         self._container = container
         self._lines: List[str] = []
         self._updated = False
@@ -72,7 +68,7 @@ class Block(ABC, Generic[T]):
         return self._lines
 
     @property
-    def container(self) -> "Container[T]":
+    def container(self) -> "Container":
         """Container holding the block"""
         if self._container is None:
             raise NotAttachedError
@@ -105,7 +101,7 @@ class Block(ABC, Generic[T]):
         return self._builder(self.container_idx + 1)
 
     @property
-    def next_block(self) -> Optional[T]:
+    def next_block(self) -> Optional["Block"]:
         """Next block in the current container"""
         idx = self.container_idx + 1
         if idx < len(self.container):
@@ -114,7 +110,7 @@ class Block(ABC, Generic[T]):
             return None
 
     @property
-    def previous_block(self) -> Optional[T]:
+    def previous_block(self) -> Optional["Block"]:
         """Previous block in the current container"""
         idx = self.container_idx - 1
         if idx >= 0:
@@ -130,7 +126,7 @@ class Block(ABC, Generic[T]):
     def is_attached(self) -> bool:
         return not (self._container is None)
 
-    def _attach(self: B, container: "Container[T]") -> B:
+    def _attach(self: B, container: "Container") -> B:
         self._container = container
         return self
 
@@ -139,9 +135,9 @@ class Block(ABC, Generic[T]):
         return self
 
 
-class Comment(Block[T]):
+class Comment(Block):
     """Comment block"""
 
 
-class Space(Block[T]):
+class Space(Block):
     """Vertical space block of new lines"""

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -22,13 +22,12 @@ else:
 if TYPE_CHECKING:
     from .section import Section
 
-from .block import Block, Comment, Space
+from .block import Block
 
-SectionContent = Union["Option", "Comment", "Space"]
 Value = Union["Option", str]
 
 
-class Option(Block[SectionContent]):
+class Option(Block):
     """Option block holding a key/value pair.
 
     Attributes:

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -67,7 +67,7 @@ T = TypeVar("T")
 E = TypeVar("E", bound=Exception)
 D = TypeVar("D", bound=Document)
 
-ConfigContent = Union["Section", "Comment", "Space"]
+Hidden = Union[Comment, Space]
 
 
 class InconsistentStateError(Exception):  # pragma: no cover (not expected to happen)
@@ -303,14 +303,11 @@ class Parser:
     def _last_block(self):
         return self._document.last_block
 
-    def _update_curr_block(
-        self, block_type: Type[Union[Comment[T], Space[T]]]
-    ) -> Union[Comment[T], Space[T]]:
+    def _update_curr_block(self, block_type: Type[Hidden]) -> Hidden:
         if isinstance(self._last_block, block_type):
             return self._last_block
         else:
-            new_block = block_type(container=self._document)  # type: ignore[arg-type]
-            # ^  the type checker is forgetting ConfigUpdater <: Container[T]
+            new_block = block_type(container=self._document)
             self._document.append(new_block)
             return new_block
 

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -32,14 +32,12 @@ from .option import Option
 T = TypeVar("T")
 S = TypeVar("S", bound="Section")
 
-ConfigContent = Union["Section", "Comment", "Space"]
-SectionContent = Union["Option", "Comment", "Space"]
+
+Content = Union["Option", "Comment", "Space"]
 Value = Union["Option", str]
 
 
-class Section(
-    Block[ConfigContent], Container[SectionContent], MutableMapping[str, "Option"]
-):
+class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     """Section block holding options
 
     Attributes:
@@ -50,7 +48,7 @@ class Section(
     def __init__(self, name: str, container: "Document"):
         self._container: "Document" = container
         self._name = name
-        self._structure: List[SectionContent] = []
+        self._structure: List[Content] = []
         self._updated = False
         super().__init__(container=container)
 


### PR DESCRIPTION
This is a follow up on #35, fixing the type errors

The previous changes have introduced some cyclic dependencies in the type system. This PR tries to solve them by removing the "type of neighbours" parameter from Block.

Unfortunately it also means that we have to settle down with invariance in some of the methods such as previous/next_block.