### PR TITLE
Fix unexpected behavior when adding a secion with __setitem__

### DIFF
--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -131,8 +131,10 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
             del self._structure[idx]
             self._structure.insert(idx, value)
         else:
-            # name the section by the key
-            value.name = key
+            if value.name != key:
+                raise ValueError(
+                    f"Set key `{key}` does not equal option key `{value.name}`"
+                )
             self.add_section(value)
 
     def __delitem__(self, key: str):

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -130,7 +130,7 @@ class Section(
             if isinstance(value, Option):
                 if value.key != key:
                     raise ValueError(
-                        f"Set key {key} does not equal option key {value.key}"
+                        f"Set key `{key}` does not equal option key `{value.key}`"
                     )
                 idx = self.__getitem__(key).container_idx
                 del self.structure[idx]

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -608,6 +608,9 @@ def test_set_item_section():
         updater["section"] = "newsection"
     sect_updater.read_string(test6_cfg_in)
     section = sect_updater["section0"]
+    with pytest.raises(ValueError):
+        updater["new_section"] = section
+    section.name = "new_section"
     updater["new_section"] = section
     assert str(updater) == test6_cfg_out_new_sect
     # test overwriting an existing section


### PR DESCRIPTION
This is a bug or at least a very strange behavior when using `__setitem__` with a `Document` object. When we do for instance:
```
updater["my_sec"] = Section("other_sec")
```
then we would just overwrite the name "other_sec" with "my_sec" instead of raising an exception that something fishy is going on. This is fixed in this PR by making it consistent to `__setitem__` within a `Section` object where we already raise an exception if the `Option`'s key is not the same as the insertion key.