### PR TITLE
Fix option object

### DIFF
--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -39,7 +39,7 @@ class Option(Block):
     def __init__(
         self,
         key: str,
-        value: Optional[str],
+        value: Optional[str] = None,
         container: Optional["Section"] = None,
         delimiter: str = "=",
         space_around_delimiters: bool = True,
@@ -47,7 +47,7 @@ class Option(Block):
     ):
         super().__init__(container=container)
         self._key = key
-        self._values: List[Optional[str]] = [value]
+        self._values: List[Optional[str]] = [] if value is None else [value]
         self._value_is_none = value is None
         self._delimiter = delimiter
         self._value: Optional[str] = None  # will be filled after join_multiline_value
@@ -56,13 +56,22 @@ class Option(Block):
         self._space_around_delimiters = space_around_delimiters
         if line:
             super().add_line(line)
+        if value is not None:
+            self.value = value
+
+    def add_value(self, value: Optional[str]):
+        """PRIVATE: this function is not part of the public API of Option.
+        It is only used internally by other classes of the package during parsing.
+        """
+        self._value_is_none = value is None
+        self._values.append(value)
 
     def add_line(self, line: str):
         """PRIVATE: this function is not part of the public API of Option.
         It is only used internally by other classes of the package during parsing.
         """
         super().add_line(line)
-        self._values.append(line.strip())
+        self.add_value(line.strip())
 
     def _join_multiline_value(self):
         if not self._multiline_value_joined and not self._value_is_none:

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -336,12 +336,14 @@ class Parser:
             raise InconsistentStateError(msg, self._fpname, self._lineno, line)
         entry = Option(
             key,
-            value,
+            value=None,
             delimiter=vi,
             container=self._last_block,
             space_around_delimiters=self._space_around_delimiters,
             line=line,
         )
+        # Initially add the value as further lines might follow
+        entry.add_value(value)
         self._last_block.add_option(entry)
 
     def _add_option_line(self, line: str):

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -146,8 +146,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
             if isinstance(value, Option):
                 option = value
             else:
-                option = Option(key, value, container=self)
-                option.value = value
+                option = Option(key, value)
             option.attach(self)
             self._structure.append(option)
 


### PR DESCRIPTION
This is a fixed found when looking at the details of PR #35 and its gist in PR #39. 

The problem is that in order to set a value in a new `Option` object one had to do:
```
option = Option(key, value, container=self)
option.value = value
```
which is strange, and inconsistent. The reason for this was that Option is used by the parser and due to multi-line values, an `Option` object can be built incrementally. This is now done with the help of a new method and thus the `Option` object is more user-friendly outside the parser.