### PR TITLE
Detach blocks when cleaning containers

### DIFF
--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -164,6 +164,8 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
             return False
 
     def clear(self):
+        for block in self._structure:
+            block.detach()
         self._structure.clear()
 
     def add_section(self, section: Union[str, Section]):

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -269,4 +269,6 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         return BlockBuilder(self, idx)
 
     def clear(self):
+        for block in self._structure:
+            block.detach()
         self._structure.clear()


### PR DESCRIPTION
Blocks hold a reference to their containers.
If someone for some reason is keeping a reference to a block, and its container is emptied via `.clear()`, it would be nice (for the sake of consistency) to guarantee that the container reference is made `None`.

There is another intriguing aspect: Python GC is based on reference counter... I don't know if keeping ghost references around in the blocks might interfere with that...