### PR TITLE
Allow section comment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Version 3.0 (development)
 
 - Added type hinting, issue #16
 - Fix parsing error of indented comment lines, issue #25
+- Allow handling of raw section comment, issue #25
 
 
 Version 2.0

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -113,7 +113,7 @@ class Parser:
         \[                                 # [
         (?P<header>[^]]+)                  # very permissive!
         \]                                 # ]
-        (?P<raw_comment>.*)                # match any comment
+        (?P<raw_comment>.*)                # match any suffix
         """
     _OPT_TMPL: str = r"""
         (?P<option>.*?)                    # very permissive!

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -113,6 +113,7 @@ class Parser:
         \[                                 # [
         (?P<header>[^]]+)                  # very permissive!
         \]                                 # ]
+        (?P<raw_comment>.*)                # match any comment
         """
     _OPT_TMPL: str = r"""
         (?P<option>.*?)                    # very permissive!
@@ -325,9 +326,10 @@ class Parser:
         else:
             self._update_curr_block(Comment).add_line(line)
 
-    def _add_section(self, sectname: str, line: str):
+    def _add_section(self, sectname: str, raw_comment: str, line: str):
         new_section = Section(sectname, container=self._document)
         new_section.add_line(line)
+        new_section.raw_comment = raw_comment
         self._document.append(new_section)
 
     def _add_option(self, key: str, vi: str, value: str, line: str):
@@ -467,7 +469,7 @@ class Parser:
                         elements_added.add(sectname)
                     # So sections can't start with a continuation line
                     optname = None
-                    self._add_section(sectname, line)  # HOOK
+                    self._add_section(sectname, mo.group("raw_comment"), line)  # HOOK
                 # no section header in the file?
                 elif cursect is None:
                     raise MissingSectionHeaderError(fpname, lineno, line)

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -47,6 +47,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     def __init__(self, name: str, container: Optional["Document"] = None):
         self._container: Optional["Document"] = container
         self._name = name
+        self._raw_comment = ""
         self._structure: List[Content] = []
         self._updated = False
         super().__init__(container=container)
@@ -112,7 +113,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         if not self.updated:
             s = super().__str__()
         else:
-            s = "[{}]\n".format(self._name)
+            s = "[{}]{}\n".format(self._name, self.raw_comment)
         for entry in self._structure:
             s += str(entry)
         return s
@@ -217,6 +218,15 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     @name.setter
     def name(self, value: str):
         self._name = str(value)
+        self._updated = True
+
+    @property
+    def raw_comment(self):
+        return self._raw_comment
+
+    @raw_comment.setter
+    def raw_comment(self, value: str):
+        self._raw_comment = value
         self._updated = True
 
     def set(self: S, option: str, value: Optional[str] = None) -> S:

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -222,10 +222,15 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
 
     @property
     def raw_comment(self):
+        """Raw comment (includes comment mark) inline with the section header"""
         return self._raw_comment
 
     @raw_comment.setter
     def raw_comment(self, value: str):
+        """Add/replace a single comment inline with the section header.
+        The given value should be a raw comment, i.e. it needs to contain the
+        comment mark.
+        """
         self._raw_comment = value
         self._updated = True
 

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1143,3 +1143,29 @@ def test_transfering_sections_and_manipulating_options():
 
     assert "option2" not in str(source1)
     assert "option2" in str(target)
+
+
+def test_section_comment():
+    section = """\
+    [section0] # section comment
+    key = value
+    """
+
+    updater = ConfigUpdater()
+    updater.read_string(dedent(section))
+
+    updater["section0"].name = "section1"
+
+    expected = """\
+    [section1] # section comment
+    key = value
+    """
+    assert str(updater) == dedent(expected)
+    assert updater["section1"].raw_comment == " # section comment"
+
+    updater["section1"].raw_comment = " # new comment"
+    expected = """\
+    [section1] # new comment
+    key = value
+    """
+    assert str(updater) == dedent(expected)


### PR DESCRIPTION
This adds the missing feature of allowing the user to get and set a section comment like
```
[section] # section comment
key  = value
```
as described in #25.

Funny enough it seems that `ConfigParser` doesn't even care if an inline comment is a real comment for sections. This can be seen in this example:
```python
section = """\
    [section0] error
    key = value
    """
parser = ConfigParser()
parser.read_string(dedent(section))
```
which doesn't raise an error.