### PR TITLE
Document deepcopy usage (4th step towards #47)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,9 +196,10 @@ With the help of two ConfigUpdater objects we can easily inject this section int
 
     (updater["metadata"].add_after
                         .space()
-                        .section(sphinx_sect))
+                        .section(sphinx_sect.detach()))
 
-This results in::
+The ``detach`` method will remove the ``build_sphinx`` section from the first object
+and add it to the second object. This results in::
 
     [metadata]
     author = Ada Lovelace
@@ -207,6 +208,25 @@ This results in::
     [build_sphinx]
     source_dir = docs
     build_dir = docs/_build
+
+Alternatively, if you want to preserve ``build_sphinx`` in both
+``ConfigUpdater`` objects (i.e., prevent it from being removed from the first
+while still adding a copy to the second), you call also rely on stdlib's
+``copy.deepcopy`` function instead of ``detach``::
+
+    from copy import deepcopy
+
+    (updater["metadata"].add_after
+                        .space()
+                        .section(deepcopy(sphinx_sect)))
+
+This technique can be used for all objects inside ConfigUpdater: sections,
+options, comments and blank spaces.
+
+Shallow copies are discouraged in the context of ConfigUpdater because each
+configuration block keeps a reference to its container to allow easy document
+editing. When doing editions (such as adding or changing options and comments)
+based on a shallow copy, the results can be unreliable and unexpected.
 
 For more examples on how the API of ConfigUpdater works it's best to take a look into the
 `unit tests`_ and read the references.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,7 +82,7 @@ Using ``add_after`` would give the same result and looks like::
                                   .comment("Ada would have loved MIT")
                                   .option("license", "MIT"))
 
-Let's say we want to rename `summary` to the more common `description`::
+Let's say we want to rename ``summary`` to the more common ``description``::
 
     updater = ConfigUpdater()
     updater.read_string(cfg)
@@ -139,9 +139,10 @@ With the help of two ConfigUpdater objects we can easily inject this section int
 
     (updater["metadata"].add_after
                         .space()
-                        .section(sphinx_sect))
+                        .section(sphinx_sect.detach()))
 
-This results in::
+The :meth:`~configupdater.block.Block.detach` method will remove the ``build_sphinx``
+section from the first object and add it to the second object. This results in::
 
     [metadata]
     author = Ada Lovelace
@@ -150,6 +151,26 @@ This results in::
     [build_sphinx]
     source_dir = docs
     build_dir = docs/_build
+
+Alternatively, if you want to preserve ``build_sphinx`` in both
+:class:`~configupdater.ConfigUpdater` objects (i.e., prevent it from being
+removed from the first while still adding a copy to the second), you call also
+rely on stdlib's :func:`copy.deepcopy` function instead of
+:meth:`~configupdater.block.Block.detach`::
+
+    from copy import deepcopy
+
+    (updater["metadata"].add_after
+                        .space()
+                        .section(deepcopy(sphinx_sect)))
+
+This technique can be used for all objects inside ConfigUpdater: sections,
+options, comments and blank spaces.
+
+Shallow copies are discouraged in the context of ConfigUpdater because each
+configuration block keeps a reference to its container to allow easy document
+editing. When doing editions (such as adding or changing options and comments)
+based on a shallow copy, the results can be unreliable and unexpected.
 
 For more examples on how the API of ConfigUpdater works it's best to take a look into the
 `unit tests`_ and read the references.

--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -30,7 +30,10 @@ class NotAttachedError(Exception):
 
 
 class AlreadyAttachedError(Exception):
-    """The block has been already attached to a container. Try to remove it first."""
+    """The block has been already attached to a container.
+    Try to remove it first using ``detach`` or create a copy using stdlib's
+    ``copy.deepcopy``.
+    """
 
     def __init__(self):
         super().__init__(self.__class__.__doc__)

--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -70,7 +70,13 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
         )
 
     def optionxform(self, optionstr) -> str:
-        """Converts an option key to lower case for unification
+        """Converts an option key for unification
+
+        By default it uses :meth:`str.lower`, which means that ConfigUpdater will
+        compare options in a case insensitive way.
+
+        This implementation mimics ConfigParser API, and can be configured as described
+        in :meth:`configparser.ConfigParser.optionxform`.
 
         Args:
              optionstr (str): key name

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -108,10 +108,17 @@ class Option(Block):
         )
 
     def optionxform(self, optionstr: str) -> str:
+        """Delegates :meth:`~configupdater.document.Document.optionxform`
+        to its parent container.
+
+        Please notice that when the option object is :obj:`detached
+        <configupdater.block.Block.detach>`, this method will simply return
+        ``optionstr`` as it is, without any changes.
+        """
         if self.has_container():
             section = cast("Section", self.container)
             return section.optionxform(optionstr)
-        return optionstr.lower()
+        return optionstr
 
     @property
     def key(self) -> str:
@@ -122,6 +129,11 @@ class Option(Block):
         self._join_multiline_value()
         self._key = value
         self._updated = True
+
+    @property
+    def raw_key(self) -> str:
+        """Equivalent to :obj:`key`, but before applying :meth:`optionxform`."""
+        return self._key
 
     @property
     def value(self) -> Optional[str]:

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -142,7 +142,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         """
         if self.has_container():
             return self.document.optionxform(optionstr)
-        return optionstr.lower()
+        return optionstr
 
     def __getitem__(self, key: str) -> "Option":
         key = self.optionxform(key)

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1226,3 +1226,26 @@ def test_section_comment():
     key = value
     """
     assert str(updater) == dedent(expected)
+
+
+def test_setitem_detached_option():
+    existing = """\
+    [section0]
+    option0 = 0
+    option1 = # No value
+    """
+
+    template1 = """\
+    [section1]
+    option1 = 1
+    """
+
+    target = ConfigUpdater()
+    target.read_string(dedent(existing))
+
+    source1 = ConfigUpdater()
+    source1.read_string(dedent(template1))
+
+    option1 = source1["section1"]["option1"].detach()
+    target["section0"]["option1"] = option1
+    assert target["section0"]["option1"] == "1"

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1248,4 +1248,4 @@ def test_setitem_detached_option():
 
     option1 = source1["section1"]["option1"].detach()
     target["section0"]["option1"] = option1
-    assert target["section0"]["option1"] == "1"
+    assert target["section0"]["option1"].value == "1"


### PR DESCRIPTION
This is the third step to fix #47 and depends on #50 . I am using a technique called [stacked pull requests](https://www.michaelagreiler.com/stacked-pull-requests/) to facilitate the review, which means that merging of the associated PRs in the reverse order makes things easier  😝.

The PR adds some docs regarding `deepcopy`.

I noticed that `usage.rst` and `README.rst` share a lot of common content (in the same way PyScaffold's `README.rst` shares content with its `features.rst`). I suppose this double bookkeeping is because GitHub does not allow rst's `include` directive? I wonder if there is another way of doing that without have to manually sync the files on every change...