### PR TITLE
Add missing type hint to Document.optionxform

### DIFF
--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -69,7 +69,7 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
             if isinstance(entry, Section) and entry.name == name
         )
 
-    def optionxform(self, optionstr) -> str:
+    def optionxform(self, optionstr: str) -> str:
         """Converts an option key to lower case for unification
 
         Args:


### PR DESCRIPTION
This is an uncorrelated PR, I just noticed this type hint missing.