### PR TITLE
Add unit test for Section.__setitem__ with detached option

### DIFF
--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1169,3 +1169,26 @@ def test_section_comment():
     key = value
     """
     assert str(updater) == dedent(expected)
+
+
+def test_setitem_detached_option():
+    existing = """\
+    [section0]
+    option0 = 0
+    option1 = # No value
+    """
+
+    template1 = """\
+    [section1]
+    option1 = 1
+    """
+
+    target = ConfigUpdater()
+    target.read_string(dedent(existing))
+
+    source1 = ConfigUpdater()
+    source1.read_string(dedent(template1))
+
+    option1 = source1["section1"]["option1"].detach()
+    target["section0"]["option1"] = option1
+    assert target["section0"]["option1"] == "1"


### PR DESCRIPTION
This is an attempt to exemplify the problems with calling `optionxform` on detached blocks as discussed in #48.

`optionxform` gets called on `option.key` which will result in a `NotAttachedError` if the option object was detached from a separate document.