### PR TITLE
Improve handling of optionxform when section/option is detached (depends on #52)

### DIFF
--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -70,7 +70,13 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
         )
 
     def optionxform(self, optionstr) -> str:
-        """Converts an option key to lower case for unification
+        """Converts an option key for unification
+
+        By default it uses :meth:`str.lower`, which means that ConfigUpdater will
+        compare options in a case insensitive way.
+
+        This implementation mimics ConfigParser API, and can be configured as described
+        in :meth:`configparser.ConfigParser.optionxform`.
 
         Args:
              optionstr (str): key name

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -108,10 +108,17 @@ class Option(Block):
         )
 
     def optionxform(self, optionstr: str) -> str:
+        """Delegates :meth:`~configupdater.document.Document.optionxform`
+        to its parent container.
+
+        Please notice that when the option object is :obj:`detached
+        <configupdater.block.Block.detach>`, this method will simply return
+        ``optionstr`` as it is, without any changes.
+        """
         if self.has_container():
             section = cast("Section", self.container)
             return section.optionxform(optionstr)
-        return optionstr.lower()
+        return optionstr
 
     @property
     def key(self) -> str:
@@ -122,6 +129,11 @@ class Option(Block):
         self._join_multiline_value()
         self._key = value
         self._updated = True
+
+    @property
+    def raw_key(self) -> str:
+        """Equivalent to :obj:`key`, but before applying :meth:`optionxform`."""
+        return self._key
 
     @property
     def value(self) -> Optional[str]:

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -142,7 +142,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         """
         if self.has_container():
             return self.document.optionxform(optionstr)
-        return optionstr.lower()
+        return optionstr
 
     def __getitem__(self, key: str) -> "Option":
         key = self.optionxform(key)

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1226,3 +1226,26 @@ def test_section_comment():
     key = value
     """
     assert str(updater) == dedent(expected)
+
+
+def test_setitem_detached_option():
+    existing = """\
+    [section0]
+    option0 = 0
+    option1 = # No value
+    """
+
+    template1 = """\
+    [section1]
+    option1 = 1
+    """
+
+    target = ConfigUpdater()
+    target.read_string(dedent(existing))
+
+    source1 = ConfigUpdater()
+    source1.read_string(dedent(template1))
+
+    option1 = source1["section1"]["option1"].detach()
+    target["section0"]["option1"] = option1
+    assert target["section0"]["option1"] == "1"

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1248,4 +1248,4 @@ def test_setitem_detached_option():
 
     option1 = source1["section1"]["option1"].detach()
     target["section0"]["option1"] = option1
-    assert target["section0"]["option1"] == "1"
+    assert target["section0"]["option1"].value == "1"


### PR DESCRIPTION
This commit should fix #53, expanding on the change proposed in #48.

It should improve consistency in the case the user configures a customised `optionxform` on ConfigUpdater, for 2 reasons:

- If the custom `optionxform` is doing something weird that is incompatible with `str.lower` (e.g. splitting on the first upper case character and joining with `_`), it is better to leave `option.key` alone...

- When importing an option form a different object, the `optionxform` transformation that matters is the one configured in the receiving object, not the one from the source.

Moreover, the added docstrings try to explicit mention all the limitations of the methods.

Obs.: This PR is stacked on top of #52 and already includes the new error case from #53.
