### PR TITLE
Remove fallback mechanism for optionxform

### DIFF
--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -115,10 +115,11 @@ class Option(Block):
     def key(self) -> str:
         """Key string associated with the option.
 
-        Please notice that usually, the option key is normalized with
-        :meth:`~configupdater.document.Document.optionxform`, however,
-        when the option object is :obj:`detached <configupdater.block.Block.detach>`,
-        this method will simply return the key as it is, without any changes.
+        Please notice that the option key is normalized with
+        :meth:`~configupdater.document.Document.optionxform`.
+
+        When the option object is :obj:`detached <configupdater.block.Block.detach>`,
+        this method will raise a :obj:`NotAttachedError`.
         """
         return self.section.document.optionxform(self._key)
 

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -107,22 +107,22 @@ class Option(Block):
             space_around_delimiters=self._space_around_delimiters,
         )
 
-    def optionxform(self, optionstr: str) -> str:
-        """Delegates :meth:`~configupdater.document.Document.optionxform`
-        to its parent container.
-
-        Please notice that when the option object is :obj:`detached
-        <configupdater.block.Block.detach>`, this method will simply return
-        ``optionstr`` as it is, without any changes.
-        """
-        if self.has_container():
-            section = cast("Section", self.container)
-            return section.optionxform(optionstr)
-        return optionstr
+    @property
+    def section(self) -> "Section":
+        return cast("Section", self.container)
 
     @property
     def key(self) -> str:
-        return self.optionxform(self._key)
+        """Key string associated with the option.
+
+        Please notice that usually, the option key is normalized with
+        :meth:`~configupdater.document.Document.optionxform`, however,
+        when the option object is :obj:`detached <configupdater.block.Block.detach>`,
+        this method will simply return the key as it is, without any changes.
+        """
+        if self.has_container():
+            return self.section.document.optionxform(self._key)
+        return self._key
 
     @key.setter
     def key(self, value: str):

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -120,9 +120,7 @@ class Option(Block):
         when the option object is :obj:`detached <configupdater.block.Block.detach>`,
         this method will simply return the key as it is, without any changes.
         """
-        if self.has_container():
-            return self.section.document.optionxform(self._key)
-        return self._key
+        return self.section.document.optionxform(self._key)
 
     @key.setter
     def key(self, value: str):


### PR DESCRIPTION
This change should address https://github.com/pyscaffold/configupdater/pull/53#issuecomment-877594376 and close #53.

---

The other thing I want to do next is to improve a little bit the error messages for `NotAttachedError` and `AlreadyAttachedError` to make it less confusing which block we are refering to (e.g., when adding an option to a detached section the user might think that `NotAttachedError` refers to the option being set, when it actually refers to the section)