### PR TITLE
Add reference to block on NotAttached/AlreadyAttachedError message

### DIFF
--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -22,10 +22,10 @@ T = TypeVar("T")
 B = TypeVar("B", bound="Block")
 
 
-def _block_short_repr(block) -> str:
+def _short_repr(block) -> str:
     if isinstance(block, str):
         return block
-    name = getattr(block, "key", None) or getattr(block, "name", None)
+    name = getattr(block, "raw_key", None) or getattr(block, "name", None)
     name = f" {name!r}" if name else ""
     return f"<{block.__class__.__name__}{name}>"
 
@@ -34,7 +34,7 @@ class NotAttachedError(Exception):
     """{block} is not attached to a container yet. Try to insert it first."""
 
     def __init__(self, block: Union[str, "Block"] = "The block"):
-        msg = cast(str, self.__class__.__doc__).format(_block_short_repr(block))
+        msg = cast(str, self.__class__.__doc__).format(block=_short_repr(block))
         super().__init__(msg)
 
 
@@ -45,7 +45,7 @@ class AlreadyAttachedError(Exception):
     """
 
     def __init__(self, block: Union[str, "Block"] = "The block"):
-        msg = cast(str, self.__class__.__doc__).format(_block_short_repr(block))
+        msg = cast(str, self.__class__.__doc__).format(block=_short_repr(block))
         super().__init__(msg)
 
 

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1063,9 +1063,9 @@ def test_add_detached_section_option_objects():
     new_sec2 = Section("new-sec2")
     new_opt = Option(key="new-key", value="new-value")
     new_sec2.add_option(new_opt)
-    updater.add_section(new_sec2)
     with pytest.raises(AlreadyAttachedError):
         sec1.add_option(new_opt)
+    updater.add_section(new_sec2)
     assert updater.has_section("new-sec2")
     assert updater["new-sec2"]["new-key"].value == "new-value"
 

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1063,9 +1063,9 @@ def test_add_detached_section_option_objects():
     new_sec2 = Section("new-sec2")
     new_opt = Option(key="new-key", value="new-value")
     new_sec2.add_option(new_opt)
+    updater.add_section(new_sec2)
     with pytest.raises(AlreadyAttachedError):
         sec1.add_option(new_opt)
-    updater.add_section(new_sec2)
     assert updater.has_section("new-sec2")
     assert updater["new-sec2"]["new-key"].value == "new-value"
 

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -67,8 +67,8 @@ def test_clear_error_message():
     clone = deepcopy(section)
     with pytest.raises(NotAttachedError) as ex:
         clone["testing"] = ""
-    assert "<Section 'option.extras_require'>" in ex.value
+    assert "<Section 'options.extras_require'>" in str(ex.value)
 
     with pytest.raises(AlreadyAttachedError) as ex:
-        section["testing"] = clone["testing"]
-    assert "<Option 'testing'>" in ex.value
+        section["testing"] = next(clone.iter_options())
+    assert "<Option 'testing'>" in str(ex.value)


### PR DESCRIPTION
... this makes it less confusing for users to understand why the error is happening in the case 2 blocks are involved in the same operation (e.g., when adding options to sections). See discussion in #56.

This PR depends on #56.