### PR TITLE
Add deepclone capabilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,9 +196,10 @@ With the help of two ConfigUpdater objects we can easily inject this section int
 
     (updater["metadata"].add_after
                         .space()
-                        .section(sphinx_sect))
+                        .section(sphinx_sect.detach()))
 
-This results in::
+The ``detach`` method will remove the ``build_sphinx`` section from the first object
+and add it to the second object. This results in::
 
     [metadata]
     author = Ada Lovelace
@@ -207,6 +208,25 @@ This results in::
     [build_sphinx]
     source_dir = docs
     build_dir = docs/_build
+
+Alternatively, if you want to preserve ``build_sphinx`` in both
+``ConfigUpdater`` objects (i.e., prevent it from being removed from the first
+while still adding a copy to the second), you call also rely on stdlib's
+``copy.deepcopy`` function instead of ``detach``::
+
+    from copy import deepcopy
+
+    (updater["metadata"].add_after
+                        .space()
+                        .section(deepcopy(sphinx_sect)))
+
+This technique can be used for all objects inside ConfigUpdater: sections,
+options, comments and blank spaces.
+
+Shallow copies are discouraged in the context of ConfigUpdater because each
+configuration block keeps a reference to its container to allow easy document
+editing. When doing editions (such as adding or changing options and comments)
+based on a shallow copy, the results can be unreliable and unexpected.
 
 For more examples on how the API of ConfigUpdater works it's best to take a look into the
 `unit tests`_ and read the references.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -82,7 +82,7 @@ Using ``add_after`` would give the same result and looks like::
                                   .comment("Ada would have loved MIT")
                                   .option("license", "MIT"))
 
-Let's say we want to rename `summary` to the more common `description`::
+Let's say we want to rename ``summary`` to the more common ``description``::
 
     updater = ConfigUpdater()
     updater.read_string(cfg)
@@ -139,9 +139,10 @@ With the help of two ConfigUpdater objects we can easily inject this section int
 
     (updater["metadata"].add_after
                         .space()
-                        .section(sphinx_sect))
+                        .section(sphinx_sect.detach()))
 
-This results in::
+The :meth:`~configupdater.block.Block.detach` method will remove the ``build_sphinx``
+section from the first object and add it to the second object. This results in::
 
     [metadata]
     author = Ada Lovelace
@@ -150,6 +151,26 @@ This results in::
     [build_sphinx]
     source_dir = docs
     build_dir = docs/_build
+
+Alternatively, if you want to preserve ``build_sphinx`` in both
+:class:`~configupdater.ConfigUpdater` objects (i.e., prevent it from being
+removed from the first while still adding a copy to the second), you call also
+rely on stdlib's :func:`copy.deepcopy` function instead of
+:meth:`~configupdater.block.Block.detach`::
+
+    from copy import deepcopy
+
+    (updater["metadata"].add_after
+                        .space()
+                        .section(deepcopy(sphinx_sect)))
+
+This technique can be used for all objects inside ConfigUpdater: sections,
+options, comments and blank spaces.
+
+Shallow copies are discouraged in the context of ConfigUpdater because each
+configuration block keeps a reference to its container to allow easy document
+editing. When doing editions (such as adding or changing options and comments)
+based on a shallow copy, the results can be unreliable and unexpected.
 
 For more examples on how the API of ConfigUpdater works it's best to take a look into the
 `unit tests`_ and read the references.

--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -30,7 +30,10 @@ class NotAttachedError(Exception):
 
 
 class AlreadyAttachedError(Exception):
-    """The block has been already attached to a container. Try to remove it first."""
+    """The block has been already attached to a container.
+    Try to remove it first using ``detach`` or create a copy using stdlib's
+    ``copy.deepcopy``.
+    """
 
     def __init__(self):
         super().__init__(self.__class__.__doc__)

--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -64,13 +64,13 @@ class Block(ABC):
             return False
 
     def __deepcopy__(self: B, memo: dict) -> B:
-        clone = self._intantiate_copy()
+        clone = self._instantiate_copy()
         clone._lines = deepcopy(self._lines, memo)
         clone._updated = self._updated
         memo[id(self)] = clone
         return clone
 
-    def _intantiate_copy(self: B) -> B:
+    def _instantiate_copy(self: B) -> B:
         """Auxiliary method that allows subclasses calling ``__deepcopy__``"""
         return self.__class__(container=None)  # allow overwrite for different init args
         # ^  A fresh copy should always be made detached from any container

--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -22,10 +22,10 @@ T = TypeVar("T")
 B = TypeVar("B", bound="Block")
 
 
-def _block_short_repr(block) -> str:
+def _short_repr(block) -> str:
     if isinstance(block, str):
         return block
-    name = getattr(block, "key", None) or getattr(block, "name", None)
+    name = getattr(block, "raw_key", None) or getattr(block, "name", None)
     name = f" {name!r}" if name else ""
     return f"<{block.__class__.__name__}{name}>"
 
@@ -34,7 +34,7 @@ class NotAttachedError(Exception):
     """{block} is not attached to a container yet. Try to insert it first."""
 
     def __init__(self, block: Union[str, "Block"] = "The block"):
-        msg = cast(str, self.__class__.__doc__).format(_block_short_repr(block))
+        msg = cast(str, self.__class__.__doc__).format(block=_short_repr(block))
         super().__init__(msg)
 
 
@@ -45,7 +45,7 @@ class AlreadyAttachedError(Exception):
     """
 
     def __init__(self, block: Union[str, "Block"] = "The block"):
-        msg = cast(str, self.__class__.__doc__).format(_block_short_repr(block))
+        msg = cast(str, self.__class__.__doc__).format(block=_short_repr(block))
         super().__init__(msg)
 
 

--- a/src/configupdater/block.py
+++ b/src/configupdater/block.py
@@ -6,6 +6,7 @@ configuration file, e.g. comments, sections, options and even sequences of white
 """
 import sys
 from abc import ABC
+from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
@@ -61,6 +62,18 @@ class Block(ABC):
             return str(self) == str(other)
         else:
             return False
+
+    def __deepcopy__(self: B, memo: dict) -> B:
+        clone = self._intantiate_copy()
+        clone._lines = deepcopy(self._lines, memo)
+        clone._updated = self._updated
+        memo[id(self)] = clone
+        return clone
+
+    def _intantiate_copy(self: B) -> B:
+        """Auxiliary method that allows subclasses calling ``__deepcopy__``"""
+        return self.__class__(container=None)  # allow overwrite for different init args
+        # ^  A fresh copy should always be made detached from any container
 
     def add_line(self: B, line: str) -> B:
         """PRIVATE: this function is not part of the public API of Block.

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -100,7 +100,7 @@ class ConfigUpdater(Document):
         self._filename: Optional[str] = None
         super().__init__()
 
-    def _intantiate_copy(self: T) -> T:
+    def _instantiate_copy(self: T) -> T:
         """Will be called by ``Container.__deepcopy__``"""
         clone = self.__class__(**self._parser_opts)
         clone._filename = self._filename

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -100,6 +100,12 @@ class ConfigUpdater(Document):
         self._filename: Optional[str] = None
         super().__init__()
 
+    def _intantiate_copy(self: T) -> T:
+        """Will be called by ``Container.__deepcopy__``"""
+        clone = self.__class__(**self._parser_opts)
+        clone._filename = self._filename
+        return clone
+
     def _parser(self, **kwargs):
         opts = {"optionxform": self.optionxform, **self._parser_opts, **kwargs}
         return Parser(**opts)

--- a/src/configupdater/container.py
+++ b/src/configupdater/container.py
@@ -39,8 +39,9 @@ class Container(ABC, Generic[T]):
         return f"<{self.__class__.__name__} {self._repr_blocks()}>"
 
     def __deepcopy__(self: C, memo: dict) -> C:
-        copy = self._intantiate_copy()
-        return copy._copy_structure(self._structure, memo)
+        clone = self._intantiate_copy()
+        memo[id(self)] = clone
+        return clone._copy_structure(self._structure, memo)
 
     def _copy_structure(self: C, structure: List[T], memo: dict) -> C:
         """``__deepcopy__`` auxiliary method also useful with multi-inheritance"""

--- a/src/configupdater/container.py
+++ b/src/configupdater/container.py
@@ -39,7 +39,7 @@ class Container(ABC, Generic[T]):
         return f"<{self.__class__.__name__} {self._repr_blocks()}>"
 
     def __deepcopy__(self: C, memo: dict) -> C:
-        clone = self._intantiate_copy()
+        clone = self._instantiate_copy()
         memo[id(self)] = clone
         return clone._copy_structure(self._structure, memo)
 
@@ -48,7 +48,7 @@ class Container(ABC, Generic[T]):
         self._structure = [b.attach(self) for b in deepcopy(structure, memo)]
         return self
 
-    def _intantiate_copy(self: C) -> C:
+    def _instantiate_copy(self: C) -> C:
         """Auxiliary method that allows subclasses calling ``__deepcopy__``"""
         return self.__class__()  # allow overwrite for different init args
 

--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -69,8 +69,14 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
             if isinstance(entry, Section) and entry.name == name
         )
 
-    def optionxform(self, optionstr: str) -> str:
-        """Converts an option key to lower case for unification
+    def optionxform(self, optionstr) -> str:
+        """Converts an option key for unification
+
+        By default it uses :meth:`str.lower`, which means that ConfigUpdater will
+        compare options in a case insensitive way.
+
+        This implementation mimics ConfigParser API, and can be configured as described
+        in :meth:`configparser.ConfigParser.optionxform`.
 
         Args:
              optionstr (str): key name

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -115,10 +115,11 @@ class Option(Block):
     def key(self) -> str:
         """Key string associated with the option.
 
-        Please notice that usually, the option key is normalized with
-        :meth:`~configupdater.document.Document.optionxform`, however,
-        when the option object is :obj:`detached <configupdater.block.Block.detach>`,
-        this method will simply return the key as it is, without any changes.
+        Please notice that the option key is normalized with
+        :meth:`~configupdater.document.Document.optionxform`.
+
+        When the option object is :obj:`detached <configupdater.block.Block.detach>`,
+        this method will raise a :obj:`NotAttachedError`.
         """
         return self.section.document.optionxform(self._key)
 

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -11,7 +11,7 @@ When editing configuration files with ConfigUpdater, a handy way of setting a mu
 :meth:`~Option.set_values` method.
 """
 import sys
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
     List = list
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 from .block import Block
 
 Value = Union["Option", str]
+T = TypeVar("T", bound="Option")
 
 
 class Option(Block):
@@ -94,6 +95,17 @@ class Option(Block):
 
     def __repr__(self) -> str:
         return f"<Option: {self._key} = {self.value!r}>"
+
+    def _intantiate_copy(self: T) -> T:
+        """Will be called by :meth:`Block.__deepcopy__`"""
+        self._join_multiline_value()
+        return self.__class__(
+            self._key,
+            self._value,
+            container=None,
+            delimiter=self._delimiter,
+            space_around_delimiters=self._space_around_delimiters,
+        )
 
     def optionxform(self, optionstr: str) -> str:
         if self.has_container():

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -96,7 +96,7 @@ class Option(Block):
     def __repr__(self) -> str:
         return f"<Option: {self._key} = {self.value!r}>"
 
-    def _intantiate_copy(self: T) -> T:
+    def _instantiate_copy(self: T) -> T:
         """Will be called by :meth:`Block.__deepcopy__`"""
         self._join_multiline_value()
         return self.__class__(

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -108,10 +108,17 @@ class Option(Block):
         )
 
     def optionxform(self, optionstr: str) -> str:
+        """Delegates :meth:`~configupdater.document.Document.optionxform`
+        to its parent container.
+
+        Please notice that when the option object is :obj:`detached
+        <configupdater.block.Block.detach>`, this method will simply return
+        ``optionstr`` as it is, without any changes.
+        """
         if self.has_container():
             section = cast("Section", self.container)
             return section.optionxform(optionstr)
-        return optionstr.lower()
+        return optionstr
 
     @property
     def key(self) -> str:
@@ -122,6 +129,11 @@ class Option(Block):
         self._join_multiline_value()
         self._key = value
         self._updated = True
+
+    @property
+    def raw_key(self) -> str:
+        """Equivalent to :obj:`key`, but before applying :meth:`optionxform`."""
+        return self._key
 
     @property
     def value(self) -> Optional[str]:

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -95,10 +95,15 @@ class Option(Block):
     def __repr__(self) -> str:
         return f"<Option: {self._key} = {self.value!r}>"
 
+    def optionxform(self, optionstr: str) -> str:
+        if self.has_container():
+            section = cast("Section", self.container)
+            return section.optionxform(optionstr)
+        return optionstr.lower()
+
     @property
     def key(self) -> str:
-        section = cast("Section", self.container)
-        return section.document.optionxform(self._key)
+        return self.optionxform(self._key)
 
     @key.setter
     def key(self, value: str):

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -107,22 +107,22 @@ class Option(Block):
             space_around_delimiters=self._space_around_delimiters,
         )
 
-    def optionxform(self, optionstr: str) -> str:
-        """Delegates :meth:`~configupdater.document.Document.optionxform`
-        to its parent container.
-
-        Please notice that when the option object is :obj:`detached
-        <configupdater.block.Block.detach>`, this method will simply return
-        ``optionstr`` as it is, without any changes.
-        """
-        if self.has_container():
-            section = cast("Section", self.container)
-            return section.optionxform(optionstr)
-        return optionstr
+    @property
+    def section(self) -> "Section":
+        return cast("Section", self.container)
 
     @property
     def key(self) -> str:
-        return self.optionxform(self._key)
+        """Key string associated with the option.
+
+        Please notice that usually, the option key is normalized with
+        :meth:`~configupdater.document.Document.optionxform`, however,
+        when the option object is :obj:`detached <configupdater.block.Block.detach>`,
+        this method will simply return the key as it is, without any changes.
+        """
+        if self.has_container():
+            return self.section.document.optionxform(self._key)
+        return self._key
 
     @key.setter
     def key(self, value: str):

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -120,9 +120,7 @@ class Option(Block):
         when the option object is :obj:`detached <configupdater.block.Block.detach>`,
         this method will simply return the key as it is, without any changes.
         """
-        if self.has_container():
-            return self.section.document.optionxform(self._key)
-        return self._key
+        return self.section.document.optionxform(self._key)
 
     @key.setter
     def key(self, value: str):

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -121,15 +121,20 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     def __repr__(self) -> str:
         return f"<Section: {self.name!r} {super()._repr_blocks()}>"
 
+    def optionxform(self, optionstr: str) -> str:
+        if self.has_container():
+            return self.document.optionxform(optionstr)
+        return optionstr.lower()
+
     def __getitem__(self, key: str) -> "Option":
-        key = self.document.optionxform(key)
+        key = self.optionxform(key)
         try:
             return next(o for o in self.iter_options() if o.key == key)
         except StopIteration as ex:
             raise KeyError(f"No option `{key}` found", {"key": key}) from ex
 
     def __setitem__(self, key: str, value: Optional[Value] = None):
-        if self.document.optionxform(key) in self:
+        if self.optionxform(key) in self:
             if isinstance(value, Option):
                 if value.key != key:
                     raise ValueError(
@@ -241,7 +246,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
             option (str): option name
             value (str): value, default None
         """
-        option = self.document.optionxform(option)
+        option = self.optionxform(option)
         if option in self.options():
             self.__getitem__(option).value = value
         else:

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -121,7 +121,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     def __repr__(self) -> str:
         return f"<Section: {self.name!r} {super()._repr_blocks()}>"
 
-    def _intantiate_copy(self: S) -> S:
+    def _instantiate_copy(self: S) -> S:
         """Will be called by :meth:`Block.__deepcopy__`"""
         clone = self.__class__(self._name, container=None)
         # ^  A fresh copy should always be made detached from any container

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -142,7 +142,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         """
         if self.has_container():
             return self.document.optionxform(optionstr)
-        return optionstr.lower()
+        return optionstr
 
     def __getitem__(self, key: str) -> "Option":
         key = self.optionxform(key)

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -121,6 +121,17 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     def __repr__(self) -> str:
         return f"<Section: {self.name!r} {super()._repr_blocks()}>"
 
+    def _intantiate_copy(self: S) -> S:
+        """Will be called by :meth:`Block.__deepcopy__`"""
+        clone = self.__class__(self._name, container=None)
+        # ^  A fresh copy should always be made detached from any container
+        clone._raw_comment = self._raw_comment
+        return clone
+
+    def __deepcopy__(self: S, memo: dict) -> S:
+        clone = Block.__deepcopy__(self, memo)  # specific due to multi-inheritance
+        return clone._copy_structure(self._structure, memo)
+
     def optionxform(self, optionstr: str) -> str:
         if self.has_container():
             return self.document.optionxform(optionstr)

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1226,3 +1226,26 @@ def test_section_comment():
     key = value
     """
     assert str(updater) == dedent(expected)
+
+
+def test_setitem_detached_option():
+    existing = """\
+    [section0]
+    option0 = 0
+    option1 = # No value
+    """
+
+    template1 = """\
+    [section1]
+    option1 = 1
+    """
+
+    target = ConfigUpdater()
+    target.read_string(dedent(existing))
+
+    source1 = ConfigUpdater()
+    source1.read_string(dedent(template1))
+
+    option1 = source1["section1"]["option1"].detach()
+    target["section0"]["option1"] = option1
+    assert target["section0"]["option1"] == "1"

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1063,9 +1063,9 @@ def test_add_detached_section_option_objects():
     new_sec2 = Section("new-sec2")
     new_opt = Option(key="new-key", value="new-value")
     new_sec2.add_option(new_opt)
-    updater.add_section(new_sec2)
     with pytest.raises(AlreadyAttachedError):
         sec1.add_option(new_opt)
+    updater.add_section(new_sec2)
     assert updater.has_section("new-sec2")
     assert updater["new-sec2"]["new-key"].value == "new-value"
 

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1248,4 +1248,4 @@ def test_setitem_detached_option():
 
     option1 = source1["section1"]["option1"].detach()
     target["section0"]["option1"] = option1
-    assert target["section0"]["option1"] == "1"
+    assert target["section0"]["option1"].value == "1"

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1063,9 +1063,9 @@ def test_add_detached_section_option_objects():
     new_sec2 = Section("new-sec2")
     new_opt = Option(key="new-key", value="new-value")
     new_sec2.add_option(new_opt)
+    updater.add_section(new_sec2)
     with pytest.raises(AlreadyAttachedError):
         sec1.add_option(new_opt)
-    updater.add_section(new_sec2)
     assert updater.has_section("new-sec2")
     assert updater["new-sec2"]["new-key"].value == "new-value"
 

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,32 @@
+from copy import deepcopy
+from textwrap import dedent
+
+import pytest
+
+from configupdater.block import NotAttachedError
+from configupdater.parser import Parser
+
+
+def test_deepcopy():
+    example = """\
+    [options.extras_require]
+    testing =   # Add here test requirements (used by tox)
+        sphinx  # required for system tests
+        flake8  # required for system tests
+    """
+    doc = Parser().read_string(dedent(example))
+    section = doc["options.extras_require"]
+    option = section["testing"]
+    assert option.container is section
+
+    clone = deepcopy(option)
+
+    assert str(clone) == str(option)
+    assert option.container is section
+    with pytest.raises(NotAttachedError):
+        assert clone.container is None  # copies should always be created detached
+
+    # Make sure no side effects are felt by the original when the copy is modified
+    clone.value = ""
+    assert str(clone) != str(option)
+    assert str(doc) == dedent(example)

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,0 +1,49 @@
+from copy import deepcopy
+from textwrap import dedent
+
+import pytest
+
+from configupdater.block import NotAttachedError
+from configupdater.parser import Parser
+
+
+def test_deepcopy():
+    example = """\
+    [options.extras_require]
+    testing =   # Add here test requirements (used by tox)
+        sphinx  # required for system tests
+        flake8  # required for system tests
+    """
+    doc = Parser().read_string(dedent(example))
+    section = doc["options.extras_require"]
+    option = section["testing"]
+    assert option.container is section
+
+    clone = deepcopy(section)
+
+    assert str(clone) == str(section)
+    assert section.container is doc
+    with pytest.raises(NotAttachedError):
+        assert clone.container is None  # copies should always be created detached
+
+    # Make sure no side effects are felt by the original when the copy is modified
+    # and vice-versa
+    clone["testing"] = ""
+    assert str(clone) != str(section)
+    assert str(doc) == dedent(example)
+    clone["testing"].add_before.option("extra_option", "extra_value")
+    assert "extra_option" in clone
+    assert "extra_option" not in section
+    assert clone["extra_option"].container is clone
+
+    section["testing"].add_before.option("other_extra_option", "other_extra_value")
+    assert "other_extra_option" in section
+    assert "other_extra_option" not in clone
+    assert section["other_extra_option"].container is section
+
+    section.add_after.comment("# new comment")
+    assert "# new comment" in str(doc)
+    assert "# new comment" not in str(clone)
+
+    with pytest.raises(NotAttachedError):
+        clone.add_before.comment("# new comment")

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -67,8 +67,8 @@ def test_clear_error_message():
     clone = deepcopy(section)
     with pytest.raises(NotAttachedError) as ex:
         clone["testing"] = ""
-    assert "<Section 'option.extras_require'>" in ex.value
+    assert "<Section 'options.extras_require'>" in str(ex.value)
 
     with pytest.raises(AlreadyAttachedError) as ex:
-        section["testing"] = clone["testing"]
-    assert "<Option 'testing'>" in ex.value
+        section["testing"] = next(clone.iter_options())
+    assert "<Option 'testing'>" in str(ex.value)


### PR DESCRIPTION
Closes #47

This PR is just a collection of previous ones that were already independently reviewed. No new code was added.
It should address the concerns previously risen, without having to interfere with `optionxform`.

---

The key for the successful implementation of `__deepcopy__` was add `option.raw_key` and calculate the normalised key using the target object's `optionxform` instead of the source object's one.

There is also a small "quality of life improvement" that clarifies which block is the reason for `NotAttachedError` and `AlreadyAttachedError` (so when adding an option to a section, the users can know if the error refers to the option or the section) and other documentation changes.