### PR TITLE
Fix logo scaling in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@
 |
 
 .. image:: https://configupdater.readthedocs.io/en/latest/_images/banner-640x323.png
-    :height: 640px
-    :width: 323px
+    :height: 323px
+    :width: 640px
     :scale: 60 %
     :alt: Config Updater
     :align: center


### PR DESCRIPTION
Somehow `width` and `height` were mixed up in the logo. This could be seen when checking [PyPI](https://pypi.org/project/ConfigUpdater/3.0rc1/).