### PR TITLE
Accept list/tuples/... as values in section.set

### DIFF
--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -15,12 +15,12 @@ from enum import Enum
 from typing import Optional, Tuple, TypeVar, Union, overload
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
-    from collections.abc import Iterator, MutableMapping
+    from collections.abc import Iterable, Iterator, MutableMapping
 
     List = list
     Dict = dict
 else:  # pragma: no cover
-    from typing import Dict, Iterator, List, MutableMapping
+    from typing import Dict, Iterable, Iterator, List, MutableMapping
 
 from .block import Comment, Space
 from .container import Container
@@ -322,23 +322,25 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
         key = self.optionxform(option)
         return key in self.get_section(section, {})
 
-    def set(self: D, section: str, option: str, value: Optional[str] = None) -> D:
+    def set(
+        self: D,
+        section: str,
+        option: str,
+        value: Union[None, str, Iterable[str]] = None,
+    ) -> D:
         """Set an option.
 
         Args:
-            section (str): section name
-            option (str): option name
-            value (str): value, default None
+            section: section name
+            option: option name
+            value: value, default None
         """
         try:
             section_obj = self.__getitem__(section)
         except KeyError:
             raise NoSectionError(section) from None
         option = self.optionxform(option)
-        if option in section_obj:
-            section_obj[option].value = value
-        else:
-            section_obj[option] = value
+        section_obj.set(option, value)
         return self
 
     def remove_option(self, section: str, option: str) -> bool:

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -14,10 +14,12 @@ import sys
 from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
+    from collections.abc import Iterable
+
     List = list
     Dict = dict
 else:
-    from typing import List  # pragma: no cover
+    from typing import Iterable, List  # pragma: no cover
 
 if TYPE_CHECKING:
     from .section import Section
@@ -146,7 +148,7 @@ class Option(Block):
         self._value = value
         self._values = [value]
 
-    def set_values(self, values: List[str], separator="\n", indent=4 * " "):
+    def set_values(self, values: Iterable[str], separator="\n", indent=4 * " "):
         """Sets the value to a given list of options, e.g. multi-line values
 
         Args:

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -267,7 +267,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         option = self.document.optionxform(option)
         if option not in self.options():
             self[option] = Option(option)
-        if isinstance(value, str) or value is None:
+        if not isinstance(value, Iterable) or isinstance(value, str):
             self[option].value = value
         else:
             self[option].set_values(value)

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -11,16 +11,15 @@ Note:
     the more usual :meth:`~collections.abc.Mapping.get` method of *dict-like* objects.
 """
 import sys
-from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union, cast, overload
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
     from collections.abc import Iterable, Iterator, MutableMapping
 
     List = list
     Dict = dict
-    Tuple = tuple
 else:  # pragma: no cover
-    from typing import Dict, Iterable, Iterator, List, MutableMapping, Tuple
+    from typing import Dict, Iterable, Iterator, List, MutableMapping
 
 if TYPE_CHECKING:
     from .document import Document

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -11,15 +11,16 @@ Note:
     the more usual :meth:`~collections.abc.Mapping.get` method of *dict-like* objects.
 """
 import sys
-from typing import TYPE_CHECKING, Optional, Tuple, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Optional, TypeVar, Union, cast, overload
 
 if sys.version_info[:2] >= (3, 9):  # pragma: no cover
-    from collections.abc import Iterator, MutableMapping
+    from collections.abc import Iterable, Iterator, MutableMapping
 
     List = list
     Dict = dict
+    Tuple = tuple
 else:  # pragma: no cover
-    from typing import Dict, Iterator, List, MutableMapping
+    from typing import Dict, Iterable, Iterator, List, MutableMapping, Tuple
 
 if TYPE_CHECKING:
     from .document import Document
@@ -256,18 +257,20 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         self._raw_comment = value
         self._updated = True
 
-    def set(self: S, option: str, value: Optional[str] = None) -> S:
+    def set(self: S, option: str, value: Union[None, str, Iterable[str]] = None) -> S:
         """Set an option for chaining.
 
         Args:
-            option (str): option name
-            value (str): value, default None
+            option: option name
+            value: value, default None
         """
         option = self.document.optionxform(option)
-        if option in self.options():
-            self.__getitem__(option).value = value
+        if option not in self.options():
+            self[option] = Option(option)
+        if isinstance(value, str) or value is None:
+            self[option].value = value
         else:
-            self.__setitem__(option, value)
+            self[option].set_values(value)
         return self
 
     @overload

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -7,6 +7,23 @@ from configupdater.block import AlreadyAttachedError, NotAttachedError
 from configupdater.parser import Parser
 
 
+def test_set():
+    example = """\
+    [options.extras_require]
+    testing =   # Add here test requirements (used by tox)
+        sphinx  # required for system tests
+        flake8  # required for system tests
+    """
+    doc = Parser().read_string(dedent(example))
+    section = doc["options.extras_require"]
+
+    section.set("all", "pyscaffold")
+    assert section["all"].value == "pyscaffold"
+
+    section.set("testing", ["pyscaffoldext-markdown", "rst-to-myst"])
+    assert section["testing"].value == "\n    pyscaffoldext-markdown\n    rst-to-myst"
+
+
 def test_deepcopy():
     example = """\
     [options.extras_require]


### PR DESCRIPTION
I have observed the following usage pattern in PyScaffold's code base:

- Calling `set` on a `Section` object without passing a value
- Calling `set_value` with a list on the same `Option` just afterwards

example:
```python

options.set("install_requires")
options["install_requires"].set_values(deps.RUNTIME)

pyscaffold.set("extensions")
pyscaffold["extensions"].set_values(sorted(old | extensions))
```

The changes proposed here allow passing a list/tuple/sequence/... of strings directly to `set` instead of doing it in 2 stages.
Additionally, I also propagate the changes upwards the chain to `Document.set`.