### PR TITLE
Improve consistency of `validate_format`

### DIFF
--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -181,6 +181,6 @@ class ConfigUpdater(Document):
         The ConfigParser object is instead with the same arguments as the original
         ConfigUpdater object, but the ``kwargs`` can be used to overwrite them.
 
-        See :method:`configupdater.Document.validate_format`.
+        See :meth:`~configupdater.document.Document.validate_format`.
         """
         return super().validate_format(**{**self._parser_opts, **kwargs})

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -157,7 +157,7 @@ class ConfigUpdater(Document):
             validate (Boolean): validate format before writing
         """
         if validate:
-            self.validate_format(**self._parser_opts)
+            self.validate_format()
         fp.write(str(self))
 
     def update_file(self: T, validate: bool = True) -> T:
@@ -169,7 +169,18 @@ class ConfigUpdater(Document):
         if self._filename is None:
             raise NoConfigFileReadError()
         if validate:  # validate BEFORE opening the file!
-            self.validate_format(**self._parser_opts)
+            self.validate_format()
         with open(self._filename, "w") as fb:
             self.write(fb, validate=False)
         return self
+
+    def validate_format(self, **kwargs):
+        """Validate INI/CFG representation by parsing it with
+        :class:`~configparser.ConfigParser`.
+
+        The ConfigParser object is instead with the same arguments as the original
+        ConfigUpdater object, but the ``kwargs`` can be used to overwrite them.
+
+        See :method:`configupdater.Document.validate_format`.
+        """
+        return super().validate_format(**{**self._parser_opts, **kwargs})

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -175,7 +175,8 @@ class ConfigUpdater(Document):
         return self
 
     def validate_format(self, **kwargs):
-        """Validate INI/CFG representation by parsing it with
+        """Given the current state of the ``ConfigUpdater`` object (e.g. after
+        modifications), validate its INI/CFG textual representation by parsing it with
         :class:`~configparser.ConfigParser`.
 
         The ConfigParser object is instead with the same arguments as the original

--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -91,10 +91,17 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
 
         Args:
             kwargs: are passed to :class:`configparser.ConfigParser`
+
+        Raises:
+            configparser.ParsingError: if syntax errors are found
+
+        Returns:
+            ``True`` when no error is found
         """
         kwargs.pop("space_around_delimiters", None)
         parser = ConfigParser(**kwargs)
         parser.read_string(str(self))
+        return True
 
     def iter_sections(self) -> Iterator[Section]:
         """Iterate only over section blocks"""

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -434,6 +434,15 @@ def test_validate_format(setup_cfg_path):
         updater.validate_format()
 
 
+def test_validate_format_propagates_kwargs(setup_cfg_path):
+    updater = ConfigUpdater(allow_no_value=True)
+    updater.read(setup_cfg_path)
+    updater.set("pyscaffold", "namespace")
+    assert updater["pyscaffold"]["namespace"].value is None
+    assert str(updater["pyscaffold"]["namespace"]) == "namespace\n"  # no `=` sign
+    assert updater.validate_format() is True
+
+
 test3_cfg_in = """
 [section]
 key = 1


### PR DESCRIPTION
This PR aims to improve the consistency of `ConfigUpdater.__init__` and `ConfigUpdater.validate_format`.
The changes implemented here automatically propagate the `kwargs` used during instantiation to validation.

This is related to a secondary suggestion in #68. 