### PR TITLE
Use `PathLike` instead of simple `str`

### DIFF
--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -22,7 +22,7 @@ else:  # pragma: no cover
 from .block import AlreadyAttachedError, Comment, NotAttachedError, Space
 from .document import Document
 from .option import NoneValueDisallowed, Option
-from .parser import Parser
+from .parser import Parser, PathLike
 from .section import Section
 
 __all__ = [
@@ -100,7 +100,7 @@ class ConfigUpdater(Document):
             "space_around_delimiters": space_around_delimiters,
         }
         self._syntax_options = ReadOnlyMapping(self._parser_opts)
-        self._filename: Optional[str] = None
+        self._filename: Optional[PathLike] = None
         super().__init__()
 
     def _instantiate_copy(self: T) -> T:
@@ -118,7 +118,7 @@ class ConfigUpdater(Document):
     def syntax_options(self) -> Mapping:
         return self._syntax_options
 
-    def read(self: T, filename: str, encoding: Optional[str] = None) -> T:
+    def read(self: T, filename: PathLike, encoding: Optional[str] = None) -> T:
         """Read and parse a filename.
 
         Args:

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -73,6 +73,11 @@ T = TypeVar("T")
 E = TypeVar("E", bound=Exception)
 D = TypeVar("D", bound=Document)
 
+if sys.version_info[:2] >= (3, 7):  # pragma: no cover
+    PathLike = Union[str, bytes, os.PathLike]
+else:  # pragma: no cover
+    PathLike = Union[str, os.PathLike]
+
 ConfigContent = Union["Section", "Comment", "Space"]
 
 
@@ -220,15 +225,15 @@ class Parser:
         return ReadOnlyMapping(self._get_args())
 
     @overload
-    def read(self, filename: str, encoding: Optional[str] = None) -> Document:
+    def read(self, filename: PathLike, encoding: Optional[str] = None) -> Document:
         ...
 
     @overload
-    def read(self, filename: str, encoding: str, into: D) -> D:
+    def read(self, filename: PathLike, encoding: str, into: D) -> D:
         ...
 
     @overload
-    def read(self, filename: str, *, into: D, encoding: Optional[str] = None) -> D:
+    def read(self, filename: PathLike, *, into: D, encoding: Optional[str] = None) -> D:
         ...
 
     def read(self, filename, encoding=None, into=None):
@@ -241,7 +246,7 @@ class Parser:
         """
         document = Document() if into is None else into
         with open(filename, encoding=encoding) as fp:
-            self._read(fp, filename, document)
+            self._read(fp, str(filename), document)
         self._filename = os.path.abspath(filename)
         return document
 


### PR DESCRIPTION
This is a small change to improve the type hints.
(since 3.6 file-related APIs in Python accept `os.PathLike` objects in addition to strings).