### PR TITLE
Add a diff tool to assist comparing changes to stdlib

### DIFF
--- a/tools/stdlib-diff.py
+++ b/tools/stdlib-diff.py
@@ -87,8 +87,11 @@ def diff_member(
         # buitins will fail if inspected
         return None
 
+    if orig_code.file.endswith("collections_abc.py"):
+        return None
+
     yield from format_patch(orig_code, changed_code, numlines)
-    yield '\n'
+    yield "\n"
 
 
 @dataclass

--- a/tools/stdlib-diff.py
+++ b/tools/stdlib-diff.py
@@ -1,0 +1,127 @@
+import argparse
+import sys
+from configparser import ConfigParser, SectionProxy
+from difflib import HtmlDiff
+from inspect import getsourcelines, getsourcefile, getmembers
+from typing import Collection, Optional, Type
+
+from bs4 import BeautifulSoup
+
+from configupdater import ConfigUpdater, Parser, Section
+from configupdater.document import Document
+
+COMPARISONS = [
+    (Parser, ConfigParser),
+    (ConfigUpdater, ConfigParser),
+    (Document, ConfigParser),
+    (Section, SectionProxy),
+]
+
+
+def meta_info(obj):
+    path = getsourcefile(obj)
+    src, start = getsourcelines(obj)
+    return src, path, start
+
+
+def diff_member(
+    name: str,
+    orig_cls: Type,
+    changed_cls: Type,
+    context: bool,
+    numlines: int,
+) -> Optional[str]:
+    orig = getattr(orig_cls, name, None)
+    changed = getattr(changed_cls, name, None)
+
+    if orig is None or changed is None:
+        return None
+
+    if not (callable(orig) and callable(changed)):
+        # Not a method
+        return None
+
+    try:
+        orig_src, orig_file, orig_line = meta_info(orig)
+        changed_src, changed_file, changed_line = meta_info(changed)
+    except TypeError:
+        # buitins will fail if inspected
+        return None
+
+    diff_table = HtmlDiff(tabsize=4, charjunk=lambda _: False).make_table(
+        orig_src,
+        changed_src,
+        fromdesc=f"{orig_file}:{orig_line}",
+        todesc=f"{changed_file}:{changed_line}",
+        context=context,
+        numlines=numlines,
+    )
+
+    mod_name = changed_cls.__module__
+    qual_name = changed_cls.__qualname__
+
+    return f"""
+    <section id="{name}">
+        <header>
+            <h2><pre>{mod_name}:{qual_name}.{name}<pre></h2>
+        </header>
+
+        {diff_table}
+    </section>
+    """
+
+
+def diff(
+    orig_cls: Type,
+    changed_cls: Type,
+    context: bool,
+    numlines: int,
+) -> str:
+    diff_fragments = (
+        diff_member(name, orig_cls, changed_cls, context, numlines)
+        for name, _ in getmembers(changed_cls)
+        if name != "__init__" and name in changed_cls.__dict__
+    )
+    return "\n".join(d for d in diff_fragments if d)
+
+
+def diff_all(context: bool, numlines: int) -> str:
+    content_str = (
+        "\n".join(
+            diff(orig, target, context, numlines) for (target, orig) in COMPARISONS
+        )
+        .encode("utf-8", "xmlcharrefreplace")
+        .decode("utf-8")
+    )
+
+    content = BeautifulSoup(f"<main>{content_str}<main>", "html.parser").main
+    page = BeautifulSoup(HtmlDiff(tabsize=4).make_file("", ""), "html.parser")
+    page.find("table").replace_with(content)
+    return page.prettify()
+
+
+def main():
+    cli = argparse.ArgumentParser()
+    cli.add_argument(
+        "--no-context",
+        action="store_false",
+        dest="context",
+        default=True,
+        help="Produce a full diff",
+    )
+    cli.add_argument(
+        "-l",
+        "--lines",
+        type=int,
+        default=3,
+        metavar="N",
+        dest="numlines",
+        help="Set number of context lines (default %(default)s)",
+    )
+    cli.add_argument("-o", "--output", type=argparse.FileType("w"), default=sys.stdout)
+    opts = cli.parse_args()
+    with opts.output as f:
+        f.write(diff_all(opts.context, opts.numlines))
+
+
+__name__ == "__main__" and main()

--- a/tools/stdlib_diff.py
+++ b/tools/stdlib_diff.py
@@ -150,7 +150,10 @@ def relativise_path(path: str) -> str:
 
 
 def main():
-    cli = argparse.ArgumentParser(usage=__doc__)
+    cli = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     cli.add_argument(
         "-l",
         "--lines",

--- a/tools/stdlib_diff.py
+++ b/tools/stdlib_diff.py
@@ -131,8 +131,6 @@ def format_patch(source: CodeInfo, target: CodeInfo, numlines=3) -> Iterator[str
 
 def line_range(start, stop, offset):
     length = stop - start
-    if not length:
-        return f"{offset + start},0"  # Start empty chunk in the previous line
     return f"{offset + start},{length}"  # Lines are counted from 1
 
 

--- a/tools/stdlib_diff.py
+++ b/tools/stdlib_diff.py
@@ -22,11 +22,10 @@ from configparser import ConfigParser, SectionProxy
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from inspect import getmembers, getsourcefile, getsourcelines
-from itertools import chain
-from typing import Optional, Sequence, Type, Iterator
+from typing import Iterator, Sequence, Type
 
 try:
-    import configupdater
+    import configupdater  # noqa
 except ImportError:
     repo = os.path.dirname(os.path.dirname(__file__))
     sys.path.append(os.path.join(repo, "src"))

--- a/tools/stdlib_diff.py
+++ b/tools/stdlib_diff.py
@@ -71,8 +71,12 @@ def diff_member(
 
     orig_code = CodeInfo.inspect(orig)
     changed_code = CodeInfo.inspect(changed)
+    title = (
+        f"{orig_cls.__module__}:{orig_cls.__qualname__}.{name} | "
+        f"{changed_cls.__module__}:{changed_cls.__qualname__}.{name}"
+    )
 
-    return "".join(format_patch(orig_code, changed_code, numlines))
+    return "".join(format_patch(orig_code, changed_code, numlines, title))
 
 
 @dataclass
@@ -93,7 +97,9 @@ class CodeInfo:
         return cls(src, path, start)
 
 
-def format_patch(source: CodeInfo, target: CodeInfo, numlines=3) -> Iterator[str]:
+def format_patch(
+    source: CodeInfo, target: CodeInfo, numlines: int = 3, title: str = ""
+) -> Iterator[str]:
     """Variation of :obj:`difflib.unified_diff` that considers line offsets."""
     started = False
     matcher = SequenceMatcher(None, source.lines, target.lines)
@@ -106,7 +112,7 @@ def format_patch(source: CodeInfo, target: CodeInfo, numlines=3) -> Iterator[str
         first, last = group[0], group[-1]
         source_range = line_range(first[1], last[2], source.starting_line)
         target_range = line_range(first[3], last[4], target.starting_line)
-        yield f"@@ -{source_range} +{target_range} @@\n"
+        yield f"@@ -{source_range} +{target_range} @@ {title}".strip() + "\n"
 
         for tag, i1, i2, j1, j2 in group:
             if tag == "equal":

--- a/tools/stdlib_diff.py
+++ b/tools/stdlib_diff.py
@@ -50,11 +50,7 @@ def diff_all(numlines: int) -> str:
     )
 
 
-def diff_class(
-    orig_cls: Type,
-    changed_cls: Type,
-    numlines: int,
-) -> Iterator[str]:
+def diff_class(orig_cls: Type, changed_cls: Type, numlines: int) -> Iterator[str]:
     diff_fragments = (
         diff_member(name, orig_cls, changed_cls, numlines)
         for name, _ in getmembers(changed_cls)
@@ -65,10 +61,7 @@ def diff_class(
 
 
 def diff_member(
-    name: str,
-    orig_cls: Type,
-    changed_cls: Type,
-    numlines: int,
+    name: str, orig_cls: Type, changed_cls: Type, numlines: int
 ) -> Iterator[str]:
     orig = getattr(orig_cls, name, None)
     changed = getattr(changed_cls, name, None)

--- a/tox.ini
+++ b/tox.ini
@@ -98,4 +98,4 @@ commands =
     # You can pipe the output of tox to `delta` or `bat` for code highlighting
     # Example: tox -qe py38-diff | delta --side-by-side
     #          tox -qe py38-diff | bat -l diff
-    python -m tools.stdlib_diff
+    python -m tools.stdlib_diff {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ passenv =
 deps =
     mypy
 commands =
-    python -m mypy src
+    python -m mypy src tools
 
 
 [testenv:publish]

--- a/tox.ini
+++ b/tox.ini
@@ -88,3 +88,16 @@ deps = twine
 commands =
     python -m twine check dist/*
     python -m twine upload {posargs:--repository testpypi} dist/*
+
+
+[testenv:py{37,38,39,310}-diff]
+usedevelop=True
+description =
+    Display the main differences between stdlib's ConfigParser and ConfigUpdater
+deps = beautifulsoup4
+passenv =
+    PORT
+commands =
+    python tools/stdlib-diff.py -o {envtmpdir}/diff.html
+    python -c 'print("\n" * 5, "Please open in your browser: http://localhost:{env:PORT:8080}/diff.html", "\n" * 5)'
+    python -m http.server --directory {envtmpdir} {env:PORT:8080}

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ commands =
 
 
 [testenv:typecheck]
-description = invoke mypy to typecheck the source code
+description = Invoke mypy to typecheck the source code
 changedir = {toxinidir}
 passenv =
     TERM
@@ -90,14 +90,12 @@ commands =
     python -m twine upload {posargs:--repository testpypi} dist/*
 
 
-[testenv:py{37,38,39,310}-diff]
+[testenv:py{37,38,39,310,311}-diff]
 usedevelop=True
 description =
-    Display the main differences between stdlib's ConfigParser and ConfigUpdater
-deps = beautifulsoup4
-passenv =
-    PORT
+    Display differences between stdlib's ConfigParser and ConfigUpdater
 commands =
-    python tools/stdlib-diff.py -o {envtmpdir}/diff.html
-    python -c 'print("\n" * 5, "Please open in your browser: http://localhost:{env:PORT:8080}/diff.html", "\n" * 5)'
-    python -m http.server --directory {envtmpdir} {env:PORT:8080}
+    # You can pipe the output of tox to `delta` or `bat` for code highlighting
+    # Example: tox -qe py38-diff | delta --side-by-side
+    #          tox -qe py38-diff | bat -l diff
+    python tools/stdlib-diff.py

--- a/tox.ini
+++ b/tox.ini
@@ -98,4 +98,4 @@ commands =
     # You can pipe the output of tox to `delta` or `bat` for code highlighting
     # Example: tox -qe py38-diff | delta --side-by-side
     #          tox -qe py38-diff | bat -l diff
-    python tools/stdlib-diff.py
+    python -m tools.stdlib_diff


### PR DESCRIPTION
Since ConfigUpdater is initially derived from the stdlib and the stdlib is a moving target, from times to times it is nice to see if there was any improvement that we are not adopting.

When I split the files to try to improve organisation, I made this comparison harder.

This is an attempt to add a tool that will make that job easier for us, even with the files being split.

Examples of how to use this little utility:

```bash
# Considering https://github.com/dandavison/delta is installed
# and that the commands python3.8 and python3.9 are available:
tox -qe py38-diff | delta --side-by-side
tox -qe py39-diff | delta --side-by-side
```