### PR TITLE
Experiment with simplified `.coveragerc`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,25 +8,3 @@ source = configupdater
 source =
     src/
     */site-packages/
-
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    # Don't complain about ellipsis (used in overloaded methods)
-    \.\.\.
-
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
-    # Don't complain about missing debug-only code:
-    def __repr__
-    if self\.debug
-
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplementedError
-
-    # Don't complain if non-runnable code isn't run:
-    if 0:
-    if __name__ == .__main__.:
-    if TYPE_CHECKING:


### PR DESCRIPTION
This is an experiment to check if we can simplify PyScaffold's `.coveragerc` template.