### PR TITLE
Experiment with simplified `.coveragerc`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -174,7 +174,7 @@ coverage_task:
     - test (Linux - Anaconda)
     - test (OS X)
   pip_install_script:
-    pip install --user --upgrade coverage coveralls pre-commit
+    pip install --user --upgrade coverage coveralls covdefaults pre-commit
   precommit_script:
     - pre-commit install
     - pre-commit run --all-files

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,25 +8,3 @@ source = configupdater
 source =
     src/
     */site-packages/
-
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    # Don't complain about ellipsis (used in overloaded methods)
-    \.\.\.
-
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
-    # Don't complain about missing debug-only code:
-    def __repr__
-    if self\.debug
-
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplementedError
-
-    # Don't complain if non-runnable code isn't run:
-    if 0:
-    if __name__ == .__main__.:
-    if TYPE_CHECKING:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,13 @@
 # .coveragerc to control coverage.py
 [run]
-branch = True
 source = configupdater
 # omit = bad_file.py
+plugins = covdefaults
 
 [paths]
 source =
     src/
     */site-packages/
+
+[report]
+fail_under = 90

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ exclude =
 testing =
     sphinx  # required for system tests
     flake8  # required for system tests
+    covdefaults
     pytest
     pytest-cov
     pytest-virtualenv


### PR DESCRIPTION
This is an experiment to check if we can simplify PyScaffold's `.coveragerc` template.

Problems with this approach:
- `covdefaults` forces the user to specify a coverage threshold (otherwise it enforces 100% coverage)