### PR TITLE
Fix section losing indentation while not updated

### DIFF
--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -337,9 +337,10 @@ class Parser:
             self._update_curr_block(Comment).add_line(line)
 
     def _add_section(self, sectname: str, raw_comment: str, line: str):
-        new_section = Section(sectname, container=self._document)
+        new_section = Section(
+            sectname, container=self._document, raw_comment=raw_comment
+        )
         new_section.add_line(line)
-        new_section.raw_comment = raw_comment
         self._document.append(new_section)
 
     def _add_option(self, key: str, vi: str, value: Optional[str], line: str):

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -44,10 +44,12 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
         updated (bool): indicates name change or a new section
     """
 
-    def __init__(self, name: str, container: Optional["Document"] = None):
+    def __init__(
+        self, name: str, container: Optional["Document"] = None, raw_comment: str = ""
+    ):
         self._container: Optional["Document"] = container
         self._name = name
-        self._raw_comment = ""
+        self._raw_comment = raw_comment
         self._structure: List[Content] = []
         self._updated = False
         super().__init__(container=container)
@@ -112,6 +114,8 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     def __str__(self) -> str:
         if not self.updated:
             s = super().__str__()
+            if self._structure and not s.endswith("\n"):
+                s += "\n"
         else:
             s = "[{}]{}\n".format(self._name, self.raw_comment)
         for entry in self._structure:

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1468,3 +1468,27 @@ def test_as_list_comma_separated():
     updater.read_string(cfg)
     option = updater["metadata"]["classifiers"]
     assert option.as_list(",") == ["terminal", "developers"]
+
+
+def test_indented_section():
+    cfg = """\
+    [section0]
+
+        [section1]
+            key = value
+    """
+
+    updater = ConfigUpdater()
+    updater.read_string(dedent(cfg))
+
+    assert str(updater) == dedent(cfg)
+
+
+def test_section_without_end_of_line():
+    cfg = """\
+    [section]"""
+
+    updater = ConfigUpdater()
+    updater.read_string(dedent(cfg))
+
+    assert str(updater) == dedent(cfg)


### PR DESCRIPTION
Fix #92.

It seems that every section is marked as `updated` upon creation because `raw_comment` is assigned using a setter. I modified the `Section` constructor so it can accept the comment directly, avoiding marking the section as updated while it isn't.

When a section isn't marked as updated, the raw line read during parsing is directly re-used for formatting. That means we won't lose indentation in this case. I didn't bother keeping indentation when the section is updated because I noticed it's the case for other objects (like `Option`) to lose indentation also when it's modified. The most important thing is that reading and rewriting without modification leaves the file unchanged, I think.

Preventing the `Section` to be marked as `updated` wasn't enough, because it broke [`test_update_file_issue_68`](https://github.com/pyscaffold/configupdater/blob/b0053814cc0de545aaf1208c733fd21d11dc8bff/tests/test_configupdater.py#L68-L84). If the section is initially empty and wasn't ending with `"\n"` while being parsed, adding an option must also causes a new line to be added to the end of the section title (otherwise, the section name and added option end up on the same line). 