### PR TITLE
Fix Sphinx duplicate object description warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.join(__location__, "../src"))
 # https://github.com/rtfd/readthedocs.org/issues/1139
 # DON'T FORGET: Check the box "Install your project inside a virtualenv using
 # setup.py install" in the RTD Advanced Settings.
-# Additionally it helps us to avoid running apidoc manually
+# Additionally, it helps us to avoid running apidoc manually
 
 try:  # for Sphinx >= 1.7
     from sphinx.ext import apidoc
@@ -46,6 +46,9 @@ except FileNotFoundError:
 try:
     import sphinx
 
+    os.environ["SPHINX_APIDOC_OPTIONS"] = "members,show-inheritance"
+    # ^ Fixes "duplicate object description" warnings as outlined under:
+    # https://github.com/sphinx-doc/sphinx/issues/8664
     cmd_line_template = (
         "sphinx-apidoc --implicit-namespaces -f -o {outputdir} {moduledir}"
     )

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -202,7 +202,7 @@ class ConfigUpdater(Document):
         return super().validate_format(**{**self._parser_opts, **kwargs})
 
 
-if False:
+if __name__ == "WILL_NOT_HAPPEN":
     # introduce no-ops to make Sphinx happy, issue #90
     _ = type(Option) is Option
     _ = type(Section) is Section

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -200,3 +200,9 @@ class ConfigUpdater(Document):
         See :meth:`~configupdater.document.Document.validate_format`.
         """
         return super().validate_format(**{**self._parser_opts, **kwargs})
+
+
+if False:
+    # introduce no-ops to make Sphinx happy, issue #90
+    _ = type(Option) is Option
+    _ = type(Section) is Section

--- a/src/configupdater/configupdater.py
+++ b/src/configupdater/configupdater.py
@@ -27,14 +27,13 @@ from .block import (
     Space,
 )
 from .document import Document
-from .option import NoneValueDisallowed, Option
+from .option import NoneValueDisallowed
 from .parser import Parser, PathLike
 from .section import Section
 
 __all__ = [
     "ConfigUpdater",
     "Section",
-    "Option",
     "Comment",
     "Space",
     "Parser",
@@ -200,9 +199,3 @@ class ConfigUpdater(Document):
         See :meth:`~configupdater.document.Document.validate_format`.
         """
         return super().validate_format(**{**self._parser_opts, **kwargs})
-
-
-if __name__ == "WILL_NOT_HAPPEN":
-    # introduce no-ops to make Sphinx happy, issue #90
-    _ = type(Option) is Option
-    _ = type(Section) is Section

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -1,4 +1,4 @@
-"""Parser for configuration files (normally ``*.cfg/*.ini``)
+"""Parser for configuration files, named normally ``*.cfg/*.ini``
 
 A configuration file consists of sections, lead by a "[section]" header,
 and followed by "name: value" entries, with continuations and such in


### PR DESCRIPTION
This addresses the Sphinx warnings as described in issue #90. We follow the solutions outlined under https://github.com/sphinx-doc/sphinx/issues/8664.