### PR TITLE
add a prepend_newline option to set_values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.2
+===========
+
+- Option ``prepend_newline`` in ``set_values`` to optionally avoid new lines, issue #104
+
 Version 3.1.1
 =============
 

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -247,7 +247,7 @@ class Option(Block):
             values (iterable): sequence of values
             separator (str): separator for values, default: line separator
             indent (optional str): indentation in case of line separator.
-                If prepend_newline is True 4 whitespaces by default, otherwise
+                If prepend_newline is `True` 4 whitespaces by default, otherwise
                 determine automatically if `None`.
             prepend_newline (bool): start with a new line or not, resp.
         """
@@ -262,7 +262,7 @@ class Option(Block):
             else:
                 indent = self.value_start_idx() * " "
 
-        # The most common default cause of multilines values prepended by a new line
+        # The most common case of multiline values being preceded by a new line
         if prepend_newline and "\n" in separator:
             values = [""] + values
             separator = separator + indent

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -259,9 +259,10 @@ class Option(Block):
                 indent = self.value_start_idx() * " "
 
         # The most common case of multiline values being preceded by a new line
-        if prepend_newline:
+        if prepend_newline and "\n" in separator:
             values = [""] + values
-        if "\n" in separator:
+            separator = separator + indent
+        elif "\n" in separator:
             separator = separator + indent
 
         self._value = separator.join(values)

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -259,10 +259,9 @@ class Option(Block):
                 indent = self.value_start_idx() * " "
 
         # The most common case of multiline values being preceded by a new line
-        if prepend_newline and "\n" in separator:
+        if prepend_newline:
             values = [""] + values
-            separator = separator + indent
-        elif "\n" in separator:
+        if "\n" in separator:
             separator = separator + indent
 
         self._value = separator.join(values)

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -107,15 +107,11 @@ class Option(Block):
         opts = getattr(document, "syntax_options", None) or {}
         value = self._value
         space = self._space_around_delimiters or opts.get("space_around_delimiters")
-        if space:
-            if determine_suffix:
-                # no space is needed if we use multi-line arguments
-                suffix = "" if str(value).startswith("\n") else " "
-            else:
-                suffix = " "
-            delim = f" {self._delimiter}{suffix}"
+        if determine_suffix and str(value).startswith("\n"):
+            suffix = ""  # no space is needed if we use multi-line arguments
         else:
-            delim = self._delimiter
+            suffix = " "
+        delim = f" {self._delimiter}{suffix}" if space else self._delimiter
         return delim
 
     def value_start_idx(self) -> int:

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1575,3 +1575,17 @@ def test_set_values_for_existing_multiline_value():
     updater.read_string(dedent(cfg_single_value_at_first))
     updater["section"]["options"].append("option2")
     assert str(updater) == dedent(exp_cfg_single_value_at_first)
+
+    exp_cfg_no_newline_indent2 = """\
+    [section]
+    options = option1
+      option2
+    """
+    updater = ConfigUpdater()
+    updater.read_string(dedent(cfg_no_newline))
+    options = updater["section"]["options"].as_list()
+    options[-1] = "option2"  # fix typo
+    updater["section"]["options"].set_values(
+        options, prepend_newline=False, indent=2 * " "
+    )
+    assert str(updater) == dedent(exp_cfg_no_newline_indent2)


### PR DESCRIPTION
This addresses the issue #104 and adds a new `prepend_newline` option to `set_values`. By default this option is `True` to reflect the current behaviour. It can be set to `False` to avoid a new line. In this case also the indentation can be automatically determined by passing `None` to `indent`. 

The changes should be 100% backward compatible and should not break anything if `prepend_newline` is not passed or `True`.