### PR TITLE
Take 2 on issue 107

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,8 @@
+API Reference
+=============
+
+.. automodule:: configupdater
+   :exclude-members: filename
+
+.. There is a rst-syntax error with configparser.ParsingError.filename
+   so we have to ignore this error otherwise Sphinx will complain.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,43 +23,6 @@ __location__ = os.path.join(
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.join(__location__, "../src"))
 
-# -- Run sphinx-apidoc -------------------------------------------------------
-# This hack is necessary since RTD does not issue `sphinx-apidoc` before running
-# `sphinx-build -b html . _build/html`. See Issue:
-# https://github.com/rtfd/readthedocs.org/issues/1139
-# DON'T FORGET: Check the box "Install your project inside a virtualenv using
-# setup.py install" in the RTD Advanced Settings.
-# Additionally it helps us to avoid running apidoc manually
-
-try:  # for Sphinx >= 1.7
-    from sphinx.ext import apidoc
-except ImportError:
-    from sphinx import apidoc
-
-output_dir = os.path.join(__location__, "api")
-module_dir = os.path.join(__location__, "../src/configupdater")
-try:
-    shutil.rmtree(output_dir)
-except FileNotFoundError:
-    pass
-
-try:
-    import sphinx
-
-    cmd_line_template = (
-        "sphinx-apidoc --implicit-namespaces -f -o {outputdir} {moduledir}"
-    )
-    cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
-
-    args = cmd_line.split(" ")
-    if tuple(sphinx.__version__.split(".")) >= ("1", "7"):
-        # This is a rudimentary parse_version to avoid external dependencies
-        args = args[1:]
-
-    apidoc.main(args)
-except Exception as e:
-    print("Running `sphinx-apidoc` failed!\n{}".format(e))
-
 # -- General configuration ---------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -88,7 +51,9 @@ source_suffix = ".rst"
 
 # options for autodoc/api-doc
 autodoc_default_options = {
+    'members': True,
     'inherited-members': True,
+    'show-inheritance': True,
 }
 
 # The encoding of source files.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ Contents
    License <license>
    Authors <authors>
    Changelog <changelog>
-   Module Reference <api/modules>
+   API Reference <api>
 
 
 Indices and tables

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,7 +30,7 @@ to write the changed configuration file to another destination. Before actually 
 ConfigUpdater will automatically check that the updated configuration file is still valid by
 parsing it with the help of ConfigParser.
 
-Many of ConfigParser's methods still exists and it's best to look them up in the :doc:`module reference <api/configupdater>`.
+Many of ConfigParser's methods still exists and it's best to look them up in the :doc:`API reference <api>`.
 Let's look at some examples.
 
 Adding and removing options

--- a/src/configupdater/__init__.py
+++ b/src/configupdater/__init__.py
@@ -15,6 +15,10 @@ except PackageNotFoundError:  # pragma: no cover
 finally:
     del version, PackageNotFoundError
 
+from . import configupdater, parser
+
 # import everything and rely on __ALL__
 from .configupdater import *  # noqa
 from .parser import *  # noqa
+
+__all__ = list(set(configupdater.__all__ + parser.__all__))

--- a/src/configupdater/option.py
+++ b/src/configupdater/option.py
@@ -50,13 +50,7 @@ class NoneValueDisallowed(SyntaxWarning):
 
 
 class Option(Block):
-    """Option block holding a key/value pair.
-
-    Attributes:
-        key (str): name of the key
-        value (str): stored value
-        updated (bool): indicates name change or a new section
-    """
+    """Option block holding a key/value pair."""
 
     def __init__(
         self,
@@ -172,6 +166,7 @@ class Option(Block):
 
     @property
     def value(self) -> Optional[str]:
+        """Value associated with the given option."""
         self._join_multiline_value()
         return self._value
 

--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -37,12 +37,7 @@ Value = Union["Option", str]
 
 
 class Section(Block, Container[Content], MutableMapping[str, "Option"]):
-    """Section block holding options
-
-    Attributes:
-        name (str): name of the section
-        updated (bool): indicates name change or a new section
-    """
+    """Section block holding options"""
 
     def __init__(
         self, name: str, container: Optional["Document"] = None, raw_comment: str = ""
@@ -240,6 +235,7 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
 
     @property
     def name(self) -> str:
+        """Name of the section"""
         return self._name
 
     @name.setter


### PR DESCRIPTION
Hi @FlorianWilhelm, I played around with the errors in #107 and I think we can safely use `autodoc` instead of `apidoc` for this one if we export `configupdater.__all__`.

In this PR I am exploring this approach, while also fixing some other minor duplications (e.g. when attribute is documented twice using a manual `Attributes:` section in napoleon and a property docstring).

There seems to be a syntax error with `configparser.ParsingError.filename` that causes another warning, so for now I am manually ignoring it.

There will probably be typecheck errors (because everyday `mypy` grows in power 😈), but I can try addressing those in a separated PR.