### PR TITLE
Update `tox.ini` to include missing actions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,9 +55,6 @@ commands =
 description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
-# NOTE: build is still experimental, please refer to the links for updates/issues
-# https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
-# https://github.com/pypa/pep517/issues/9
 skip_install = True
 changedir = {toxinidir}
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@
 [tox]
 minversion = 3.15
 envlist = default
+isolated_build = True
 
 
 [testenv]
 description = Invoke pytest to run automated tests
-isolated_build = True
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
@@ -20,9 +20,35 @@ deps =
 extras =
     testing
 commands =
+    pytest {posargs}
     default: py.test -k "not system" {posargs}
     system: py.test -k system {posargs}
     all: py.test -vv {posargs}
+
+
+[testenv:lint]
+description = Perform static analysis and style checks
+skip_install = True
+deps = pre-commit
+passenv =
+    HOMEPATH
+    PROGRAMDATA
+    SETUPTOOLS_*
+    TERM
+commands =
+    pre-commit run --all-files {posargs:--show-diff-on-failure}
+
+
+[testenv:typecheck]
+description = Invoke mypy to typecheck the source code
+changedir = {toxinidir}
+passenv =
+    TERM
+    # ^ ensure colors
+deps =
+    mypy
+commands =
+    python -m mypy src tools
 
 
 [testenv:{build,clean}]
@@ -31,7 +57,7 @@ description =
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
 # NOTE: build is still experimental, please refer to the links for updates/issues
 # https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
-# https://github.com/pypa/pep517/issues/91
+# https://github.com/pypa/pep517/issues/9
 skip_install = True
 changedir = {toxinidir}
 deps =
@@ -59,18 +85,6 @@ deps =
     # ^  requirements.txt shared with Read The Docs
 commands =
     sphinx-build --color -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
-
-
-[testenv:typecheck]
-description = Invoke mypy to typecheck the source code
-changedir = {toxinidir}
-passenv =
-    TERM
-    # ^ ensure colors
-deps =
-    mypy
-commands =
-    python -m mypy src tools
 
 
 [testenv:publish]


### PR DESCRIPTION
I noticed that the CI was failing on the main because of a missing part in `tox.ini`
(probably because of some failed copy+paste from the latest PyScaffold templates).