### PR TITLE
Reverse order in example to avoid confusion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,14 +161,15 @@ before ``metadata`` with a comment and two new lines to separate it from ``metad
     updater = ConfigUpdater()
     updater.read_string(cfg)
     (updater["metadata"].add_before
-                        .comment("Some specific project options")
                         .section("options")
+                        .comment("Some specific project options")
                         .space(2))
 
 As expected, this results in::
 
-    # Some specific project options
     [options]
+    # Some specific project options
+
 
     [metadata]
     author = Ada Lovelace


### PR DESCRIPTION
In #117 it was pointed out that the existing example may lead users to think comments that precede sections belong to those sections (which is not the case).

The idea behind this PR is to fix the example to avoid such interpretation.