### PR TITLE
Fix square brackets not parsed in section names

### DIFF
--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -117,7 +117,7 @@ class Parser:
     # Regular expressions for parsing section headers and options
     _SECT_TMPL: str = r"""
         \[                                 # [
-        (?P<header>[^]]+)                  # very permissive!
+        (?P<header>.+)                     # very permissive!
         \]                                 # ]
         (?P<raw_comment>.*)                # match any suffix
         """

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -1589,3 +1589,16 @@ def test_set_values_for_existing_multiline_value():
         options, prepend_newline=False, indent=2 * " "
     )
     assert str(updater) == dedent(exp_cfg_no_newline_indent2)
+
+
+def test_parsing_of_brackets_in_section_names():
+    cfg = """\
+    [ ]
+    [[]]
+    [][]
+    []#]#
+    """
+    cfg = dedent(cfg)
+    updater = ConfigUpdater()
+    updater.read_string(cfg)
+    assert updater.sections() == [" ", "[]", "][", "]#"]


### PR DESCRIPTION
Fix #121.

I assume it's safe to use a greedy regex. :)