### PR TITLE
Overloaded get methods to return fallback Option

### DIFF
--- a/src/configupdater/section.py
+++ b/src/configupdater/section.py
@@ -299,11 +299,18 @@ class Section(Block, Container[Content], MutableMapping[str, "Option"]):
     def get(self, key: str, default: T) -> Union["Option", T]:
         ...
 
-    def get(self, key, default=None):
+    @overload
+    def get(self, key: str, default: T, returnOption: bool) -> Optional["Option"]:
+        ...
+
+    def get(self, key, default=None, returnOption=False):
         """This method works similarly to :meth:`dict.get`, and allows you
         to retrieve an option object by its key.
         """
-        return next((o for o in self.iter_options() if o.key == key), default)
+        return next(
+            (o for o in self.iter_options() if o.key == key),
+            Option(key, default) if returnOption else default,
+        )
 
     # The following is a pragmatic violation of Liskov substitution principle
     # For some reason MutableMapping.items return a Set-like object


### PR DESCRIPTION
This PR adds overloaded `get` methods to both `Section` and `Document` classes with an additional parameter of type `bool` called `returnOption`. If set to `True` (defaults to `False`) then any fallback value returned will be a new object of type `Option` rather than simply the value of the fallback parameter. This option will have the value of the `option` parameter as its key and the `fallback` or `default` parameter as its value.

Of note, this new option will **not** be attached to any section, which may not be the desired result. I made that choice because I don't believe that the actual config file should be updated to include any default/fallback options if the user decides to save the file later. Rather, these should be explicitly added.

Similarly, a new overloaded `get_section` method has been added to the `Document` class which has the same behaviour as described above but for `Section `objects. Again, these will be created as orphan sections and not attached to the document.