### PR TITLE
Fix sphinx config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -17,6 +22,5 @@ formats:
   - pdf
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
`build.os` is now mandatory in `.readthedocs.yml`.

(RTD will not automatically assume that you want the latest ubuntu, which is a deliberate choice from the devs).

See https://github.com/readthedocs/readthedocs.org/issues/8861#issuecomment-1025568797.