### PR TITLE
Ensure newline before new section when file lacks trailing newline

### DIFF
--- a/src/configupdater/document.py
+++ b/src/configupdater/document.py
@@ -202,6 +202,13 @@ class Document(Container[ConfigContent], MutableMapping[str, Section]):
         if self.has_section(section_obj.name):
             raise DuplicateSectionError(section_obj.name)
 
+        # Ensure a newline before the new section if the last block
+        # doesn't end with one (e.g. file without trailing newline)
+        if self._structure and not str(self._structure[-1]).endswith("\n"):
+            space = Space(container=self)
+            space.add_line("\n")
+            self._structure.append(space)
+
         section_obj.attach(self)
         self._structure.append(section_obj)
 

--- a/tests/test_configupdater.py
+++ b/tests/test_configupdater.py
@@ -625,6 +625,15 @@ def test_add_section():
         updater.add_section(updater["section2"]["key1"])
 
 
+def test_add_section_no_trailing_newline():
+    updater = ConfigUpdater()
+    updater.read_string("[section1]\noption1 = value1\noption2 = value2")
+    updater.add_section("section2")
+    result = str(updater)
+    assert "value2\n[section2]" in result
+    assert "value2[section2]" not in result
+
+
 test6_cfg_out_overwritten = """
 [section0]
 key0 = 42


### PR DESCRIPTION
Fixes #126.

When a config file doesn't end with a newline, `add_section()` appends the section header directly after the last value, producing malformed output like `option2 = value2[section2]`.

The fix inserts a newline before the new section when the last existing block in the document doesn't end with one. Files that already have a trailing newline are unaffected.
