### PR TITLE
Preserve a usable delimiter when assigning a value to a bare option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,4 @@ Contributors
 * Florian Wilhelm <florian.wilhelm@gmail.com>
 * Christian Theune <ct@flyingcircus.io>
 * Anderson Bravalheri <andersonbravalheri@gmail.com>
+* codeofwxz (GitHub)

--- a/src/configupdater/parser.py
+++ b/src/configupdater/parser.py
@@ -339,6 +339,9 @@ class Parser:
         if not isinstance(self._last_block, Section):  # pragma: no cover
             msg = f"{self._last_block!r} should be Section"
             raise InconsistentStateError(msg, self._fpname, self._lineno, line)
+        # A no-value option needs a delimiter if a value is assigned later.
+        if vi is None and self._delimiters:
+            vi = self._delimiters[0]
         entry = Option(
             key,
             value=None,

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,4 +1,6 @@
 from copy import deepcopy
+from configparser import ConfigParser
+from io import StringIO
 from textwrap import dedent
 
 import pytest
@@ -51,3 +53,60 @@ def test_str_for_set_values():
     opt = Option("opt")
     opt.set_values("1234", separator=", ")
     assert str(opt) == "opt = 1, 2, 3, 4\n"
+
+
+@pytest.mark.parametrize("delimiters", [("=", ":"), (":", "="), ("=>", ":"), ":="])
+@pytest.mark.parametrize("spaces", [True, False])
+def test_assign_value_to_parsed_no_value_option(delimiters, spaces):
+    source = "# keep comment\n[options]\nColor\n\nOther : unchanged\n"
+    cfg = ConfigUpdater(
+        allow_no_value=True,
+        delimiters=delimiters,
+        space_around_delimiters=spaces,
+    ).read_string(source)
+    assert str(cfg) == source
+    delimiter = f" {delimiters[0]} " if spaces else delimiters[0]
+    for value in [None, "", "yes", None, "no"]:
+        cfg["options"]["Color"] = value
+        line = "Color\n" if value is None else f"Color{delimiter}{value}\n"
+        output = StringIO()
+        cfg.write(output)
+        assert output.getvalue() == source.replace("Color\n", line)
+        parser = ConfigParser(allow_no_value=True, delimiters=delimiters)
+        parser.read_string(output.getvalue())
+        assert dict(parser["options"]) == {"color": value, "other": "unchanged"}
+
+
+@pytest.mark.parametrize("prepend_newline", [True, False])
+def test_set_multiline_values_on_parsed_no_value_option(prepend_newline):
+    cfg = ConfigUpdater(allow_no_value=True, delimiters=(":",)).read_string(
+        "[options]\nColor\n"
+    )
+    cfg["options"]["Color"].set_values(["red", "blue"], prepend_newline=prepend_newline)
+    expected = (
+        "Color :\n    red\n    blue\n"
+        if prepend_newline
+        else "Color : red\n        blue\n"
+    )
+    assert str(cfg) == "[options]\n" + expected
+    parser = ConfigParser(delimiters=(":",))
+    parser.read_string(str(cfg))
+    assert parser["options"]["color"] == (
+        "\nred\nblue" if prepend_newline else "red\nblue"
+    )
+
+
+def test_no_value_option_keeps_parser_delimiter_when_copied():
+    doc = Parser(allow_no_value=True, delimiters=(":",)).read_string(
+        "[options]\nColor\n"
+    )
+    clone = deepcopy(doc["options"]["Color"])
+    clone.value = "yes"
+    assert str(clone) == "Color : yes\n"
+    assert str(doc) == "[options]\nColor\n"
+
+
+def test_existing_option_keeps_its_delimiter_after_assignment():
+    cfg = ConfigUpdater(delimiters=("=", ":")).read_string("[options]\nColor : red\n")
+    cfg["options"]["Color"] = "blue"
+    assert str(cfg) == "[options]\nColor : blue\n"


### PR DESCRIPTION
Assigning a value to an option parsed without a delimiter currently writes the literal `None` as the delimiter. For example, updating `Color` to `yes` produces `Color None yes`, which is read back as a different key with no value.

Remember the parser's first configured delimiter for these options, so later assignments produce `Color = yes` by default or `Color:yes` with a colon-only, no-space configuration. Existing delimiters and untouched source text are preserved. Keeping this on the option also supports the standalone `Parser` API and copied options.

Regression coverage includes delimiter order and string configuration, empty and `None` values, repeated assignments, multiline values, copying, and ConfigParser readback.

A separate follow-up commit updates only the pyupgrade hook from v3.18.0 to v3.21.2. The old hook crashes under Python 3.14 in `tokenize.cookie_re.match(token.src)`; this was reproduced on the original PR head. All other hook versions and `--py38-plus` remain unchanged. The new hook requires Python 3.10+ for the development environment; the package's runtime requirements are unchanged.

Validation of the combined feature and hook change: all 105 tests pass on Windows with Python 3.9.13 and 3.14.4. All 15 applicable pre-commit hooks pass under Python 3.14.4; the JSON hook skips because there are no matching files. No hook rewrote project code. Hosted pre-commit.ci and ReadTheDocs both pass on follow-up commit 5716f00ce9c437c06f739feb3e9b0f64051acd82.

Earlier package build and flake8 checks passed. `mypy src tools` reported the same three existing errors in `builder.py` and `section.py` on both the feature change and a clean baseline with mypy 2.3.1. ReadTheDocs passed on the original PR head.

Fixes #141.
